### PR TITLE
fix: in go mod version of qtalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ func main() {
 [examples/largetype](https://github.com/progrium/macdriver/blob/main/examples/largetype/main.go#L1) - A Contacts/Quicksilver-style Large Type utility in under 80 lines:
 ![largetype screenshot](https://pbs.twimg.com/media/EqaoO2MXIAEJNK2?format=jpg&name=large)
 
+
+> Note: topframe currently relies on [embed](https://github.com/golang/go/issues/41191) which you can use with go [1.16beta](https://golang.org/dl/#unstable)
+
 [examples/topframe](https://github.com/progrium/macdriver/blob/main/examples/topframe/main.go#L1) - A non-interactive, always-on-top webview with transparent background in 120 lines so you can draw on your
 screen with HTML/JS: 
 ![topframe screenshot](https://pbs.twimg.com/media/EqhYDmlW8AEBC6-?format=jpg&name=large)

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,8 @@ module github.com/progrium/macdriver
 go 1.14
 
 require (
-	github.com/manifold/qtalk v0.0.0
+	github.com/manifold/qtalk v0.0.0-20201222233608-81c04ab41f37
 	github.com/mitchellh/mapstructure v1.4.0
 	github.com/progrium/watcher v1.0.7
 	github.com/rs/xid v1.2.1
 )
-

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/manifold/qtalk v0.0.0-20201222233608-81c04ab41f37 h1:EJzvkTRn7n8ktOrMN9up7t3qXj37zxjTGVg9uR3ak2A=
+github.com/manifold/qtalk v0.0.0-20201222233608-81c04ab41f37/go.mod h1:UX1KjRclAJyV+ydrpEO1CnF8x95Le/Adx8BMGPJaYqg=
 github.com/mitchellh/mapstructure v1.4.0 h1:7ks8ZkOP5/ujthUsT07rNv+nkLXCQWKNHuwzOAesEks=
 github.com/mitchellh/mapstructure v1.4.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/progrium/watcher v1.0.7 h1:A+ciAtU09mHrTW0tdODa6SwWEuKMKF+n/vBJYNU/FqE=


### PR DESCRIPTION
There was an invalid version mentioned in the committed go.mod which lead to not beeng able to build. One of the examples also uses embed and therefore relies on go 1.16. 

I have two more suggestions:
1. maybe start thinking about tagging versions in qtalk
2. maybe setting the required go version to 1.16 in the go mod as soon as its released