### PR TITLE
feat: add collection behavior to NSWindow

### DIFF
--- a/cocoa/NSWindow.go
+++ b/cocoa/NSWindow.go
@@ -185,3 +185,10 @@ func (w NSWindow) SetBackgroundColor(color NSColor) {
 func (w NSWindow) SetFrameDisplay(frame core.NSRect, display bool) {
 	w.Send("setFrame:display:", frame, display)
 }
+
+func (w NSWindow) CollectionBehavior() int64 {
+	return w.Get("collectionBehavior").Int()
+}
+func (w NSWindow) SetCollectionBehavior(collectionBehavior int) {
+	w.Set("collectionBehavior:", collectionBehavior)
+}

--- a/cocoa/NSWindowCollectionBehavior.go
+++ b/cocoa/NSWindowCollectionBehavior.go
@@ -1,0 +1,17 @@
+package cocoa
+
+const (
+	NSWindowCollectionBehaviorDefault                   = 0
+	NSWindowCollectionBehaviorCanJoinAllSpaces          = 1 << 0
+	NSWindowCollectionBehaviorMoveToActiveSpace         = 1 << 1
+	NSWindowCollectionBehaviorManaged                   = 1 << 2
+	NSWindowCollectionBehaviorTransient                 = 1 << 3
+	NSWindowCollectionBehaviorStationary                = 1 << 4
+	NSWindowCollectionBehaviorParticipatesInCycle       = 1 << 5
+	NSWindowCollectionBehaviorIgnoresCycle              = 1 << 6
+	NSWindowCollectionBehaviorFullScreenPrimary         = 1 << 7
+	NSWindowCollectionBehaviorFullScreenAuxiliary       = 1 << 8
+	NSWindowCollectionBehaviorFullScreenNone            = 1 << 9
+	NSWindowCollectionBehaviorFullScreenAllowsTiling    = 1 << 11
+	NSWindowCollectionBehaviorFullScreenDisallowsTiling = 1 << 12
+)

--- a/examples/topframe/main.go
+++ b/examples/topframe/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -22,6 +23,9 @@ import (
 )
 
 func main() {
+	spacesFlag := flag.Bool("spaces", true, "appear on all spaces")
+	flag.Parse()
+
 	runtime.LockOSThread()
 	var err error
 
@@ -80,6 +84,9 @@ func main() {
 		w.SetIgnoresMouseEvents(true)
 		w.SetLevel(cocoa.NSMainMenuWindowLevel + 2)
 		w.MakeKeyAndOrderFront(w)
+		if *spacesFlag {
+			w.SetCollectionBehavior(cocoa.NSWindowCollectionBehaviorCanJoinAllSpaces)
+		}
 
 		events := make(chan cocoa.NSEvent)
 		go func() {


### PR DESCRIPTION
This PR has 3 parts:
- Part 1 adds the NSWindowCollectionBehavior Constants
- Part 2 adds the wrapper to get and set the collectionBehavior on a NSWindow
- Part 3 uses this to add a flag to example/topframe called `spaces` which allows rendering the window on all virtual desktops (called spaces on macos)