### PR TITLE
topframe: Use ipv4

### DIFF
--- a/examples/_topframe/main.go
+++ b/examples/_topframe/main.go
@@ -70,7 +70,7 @@ func main() {
 		wv.SetBackgroundColor(cocoa.NSColor_Clear())
 		wv.SetValueForKey(core.False, core.String("drawsBackground"))
 
-		url := core.URL(fmt.Sprintf("http://%s", ln.Addr().String()))
+		url := core.URL(fmt.Sprintf("http://localhost:%d", ln.Addr().(*net.TCPAddr).Port))
 		req := core.NSURLRequest_Init(url)
 		wv.LoadRequest(req)
 


### PR DESCRIPTION
If I'm connected to an ipv6 network the default repr of the Addr is in ipv6 format which fails to load.

This change forces use of localhost which works consistently for me. 