### PR TITLE
Implement objc method swizzling

### DIFF
--- a/examples/notification/main.go
+++ b/examples/notification/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"github.com/progrium/macdriver/cocoa"
+	"github.com/progrium/macdriver/core"
+	"github.com/progrium/macdriver/objc"
+)
+
+type NSUserNotification struct {
+	objc.Object
+}
+
+var NSUserNotification_ = objc.Get("NSUserNotification")
+
+type NSUserNotificationCenter struct {
+	objc.Object
+}
+
+var NSUserNotificationCenter_ = objc.Get("NSUserNotificationCenter")
+
+func main() {
+	app := cocoa.NSApp_WithDidLaunch(func(_ objc.Object) {
+		notification := NSUserNotification{NSUserNotification_.Alloc().Init()}
+		notification.Set("title:", core.NSString_FromString("Hello, world!"))
+		notification.Set("informativeText:", core.NSString_FromString("More text"))
+
+		center := NSUserNotificationCenter{NSUserNotificationCenter_.Send("defaultUserNotificationCenter")}
+		center.Send("deliverNotification:", notification)
+		notification.Release()
+	})
+
+	nsbundle := cocoa.NSBundle_Main().Send("class").(objc.Class)
+	objc.TODO_RegisterClassInMap(nsbundle)
+
+	nsbundle.AddMethod("__bundleIdentifier", func(_ objc.Object) objc.Object {
+		return core.NSString_FromString("com.example.fake")
+	})
+	nsbundle.Swizzle("bundleIdentifier", "__bundleIdentifier")
+
+	app.SetActivationPolicy(cocoa.NSApplicationActivationPolicyRegular)
+	app.ActivateIgnoringOtherApps(true)
+	app.Run()
+}

--- a/examples/notification/main.go
+++ b/examples/notification/main.go
@@ -29,8 +29,7 @@ func main() {
 		notification.Release()
 	})
 
-	nsbundle := cocoa.NSBundle_Main().Send("class").(objc.Class)
-	objc.TODO_RegisterClassInMap(nsbundle)
+	nsbundle := cocoa.NSBundle_Main().Class()
 
 	nsbundle.AddMethod("__bundleIdentifier", func(_ objc.Object) objc.Object {
 		return core.NSString_FromString("com.example.fake")

--- a/objc/class.go
+++ b/objc/class.go
@@ -125,18 +125,16 @@ func NewClass(classname string, superclass string) Class {
 	typeInfo := encVoid + encId + encSelector
 	C.GoObjc_ClassAddMethod(ptr, sel, methodCallTarget(), C.CString(typeInfo))
 
-	classMap[classname] = classInfo{
-		typ:       reflect.TypeOf(struct{ Object }{}),
-		methodMap: make(map[string]interface{}),
-		setters:   map[string]struct{}{},
-	}
-
+	lazilyRegisterClassInMap(classname)
 	return object{ptr: uintptr(ptr)}
 }
 
-func TODO_RegisterClassInMap(cls Class) {
-	obj := cls.(object)
-	classMap[obj.className()] = classInfo{
+func lazilyRegisterClassInMap(className string) {
+	if _, found := classMap[className]; found {
+		return
+	}
+
+	classMap[className] = classInfo{
 		typ:       reflect.TypeOf(struct{ Object }{}),
 		methodMap: map[string]interface{}{},
 		setters:   map[string]struct{}{},

--- a/objc/object.go
+++ b/objc/object.go
@@ -25,6 +25,10 @@ type Object interface {
 	// super class instead.
 	SendSuper(selector string, args ...interface{}) Object
 
+	// Class returns the the special class object corresponding
+	// to this object.
+	Class() Class
+
 	// Alloc sends the  "alloc" message to the object.
 	Alloc() Object
 
@@ -88,6 +92,12 @@ func ObjectPtr(ptr uintptr) Object {
 // be converted to an unsafe.Pointer.
 func (obj object) Pointer() uintptr {
 	return obj.ptr
+}
+
+func (obj object) Class() Class {
+	cls := obj.Send("class").(Class)
+	lazilyRegisterClassInMap(cls.(object).className())
+	return cls
 }
 
 func (obj object) Equals(o Object) bool {


### PR DESCRIPTION
Hi,

This is a great project - I love your work. I've got a PR to add method swizzling for Objective-C methods. I've also included an example to show one of the reasons this is useful. I want to be able to show the user notifications from a Golang binary. `NSNotificationCenter` refuses to do this if `[[NSBundle mainBundle] bundleIdentifier]`, which is the case for non-`.app` apps.

I don't expect this to be merged as-is, it's more a concrete example to get your thoughts. Specifically, `TODO_RegisterClassInMap` is likely something you wouldn't want. I suppose there are a few options:

1. (At startup?) Enumerate the list of all classes registered with the runtime using `objc_copyClassList` and add them all to the `classMap`. 

2. Register pre-existing classes (and their methods) lazily in `MethodForSelector`. 

3. Something else entirely.

What are your thoughts?