### PR TITLE
Fix _topframe example to use go1.16 embed and updated KeyCode() return values

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.14.x, 1.15.x, 1.16.x]
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -14,5 +14,9 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
+    - name: Build
+      run: | 
+           go build ./...
+           go build ./cmd/*
     - name: Test
       run: go test ./...

--- a/examples/_topframe/main.go
+++ b/examples/_topframe/main.go
@@ -22,6 +22,9 @@ import (
 	"github.com/progrium/watcher"
 )
 
+//go:embed index.html
+var defaultIndex []byte
+
 func main() {
 	spacesFlag := flag.Bool("spaces", true, "appear on all spaces")
 	flag.Parse()
@@ -37,8 +40,6 @@ func main() {
 	dir := filepath.Join(usr.HomeDir, ".topframe")
 	os.MkdirAll(dir, 0755)
 
-	//go:embed index.html
-	var defaultIndex []byte
 	if _, err := os.Stat(filepath.Join(dir, "index.html")); os.IsNotExist(err) {
 		ioutil.WriteFile(filepath.Join(dir, "index.html"), defaultIndex, 0644)
 	}
@@ -91,7 +92,8 @@ func main() {
 		events := make(chan cocoa.NSEvent)
 		go func() {
 			for e := range events {
-				if e.KeyCode() == 100 {
+				k, _ := e.KeyCode()
+				if k == 100 {
 					if w.IgnoresMouseEvents() {
 						fmt.Println("Mouse events on")
 						w.SetIgnoresMouseEvents(false)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/progrium/macdriver
 
-go 1.14
-
 require (
 	github.com/manifold/qtalk v0.0.0-20201222233608-81c04ab41f37
 	github.com/mitchellh/mapstructure v1.4.0


### PR DESCRIPTION
I was seeing an error when trying to build and run `examples/_topframe/main.go`
```
$  go run examples/_topframe/main.go
# command-line-arguments
examples/_topframe/main.go:40:4: go:embed cannot apply to var inside func
examples/_topframe/main.go:94:17: multiple-value e.KeyCode() in single-value context
```


This also required updating `go.mod` to `1.16` which is now officially released (but unsure if this project wanted to update to that minimum version yet just for the example). Alternatively you could add  a `go.mod` to `examples/_topframe/go.mod` at go1.16, but I'm not sure that's best practice and makes it a bit confusing.

```
$ go run examples/_topframe/main.go
# command-line-arguments
examples/_topframe/main.go:25:3: go:embed requires go1.16 or later (-lang was set to go1.14; check go.mod)
```


Added a `Build` step to the Github actions CI to ensure examples / cmd is built to report any compilation errors:
```
    - name: Build
      run: | 
           go build ./...
           go build ./cmd/*
           go build ./examples/*
```