### PR TITLE
improvement(pomodoro-example): use dispatch

### DIFF
--- a/examples/pomodoro/main.go
+++ b/examples/pomodoro/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/progrium/macdriver/core"
 	"runtime"
 	"time"
 
 	"github.com/progrium/macdriver/cocoa"
+	"github.com/progrium/macdriver/core"
 	"github.com/progrium/macdriver/objc"
 )
 

--- a/examples/pomodoro/main.go
+++ b/examples/pomodoro/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/progrium/macdriver/core"
 	"runtime"
 	"time"
 
@@ -51,7 +52,11 @@ func main() {
 					2: "✅ Finished %02d:%02d",
 					3: "⏸️ Break %02d:%02d",
 				}
-				obj.Button().SetTitle(fmt.Sprintf(labels[state], timer/60, timer%60))
+				// updates to the ui should happen on the main thread to avoid strange bugs
+				core.Dispatch(func() {
+					obj.Button().SetTitle(fmt.Sprintf(labels[state], timer/60, timer%60))
+
+				})
 			}
 		}()
 		nextClicked <- true


### PR DESCRIPTION
This PR updates the pomodoro-example to use `core.Dispatch` to force ui update on the main thread.

Motivation is to:
 - document correct usage
 - avoid bugs discovered in issue #18 and issue #15