### PR TITLE
add support for NSPasteboard

### DIFF
--- a/cocoa/NSPasteboard.go
+++ b/cocoa/NSPasteboard.go
@@ -12,13 +12,6 @@ type NSPasteboardType = string
 /*
 Code to get the values for those constants:
 ```objc
-//
-//  main.m
-//  test-objc
-//
-//  Created by Jonas Faber on 16.02.21.
-//
-
 #import <Foundation/Foundation.h>
 #import <AppKit/NSPasteboard.h>
 #import <AppKit/NSTextView.h>

--- a/cocoa/NSPasteboard.go
+++ b/cocoa/NSPasteboard.go
@@ -1,0 +1,115 @@
+package cocoa
+
+import (
+	"github.com/progrium/macdriver/core"
+	"github.com/progrium/macdriver/objc"
+)
+
+// The supported pasteboard types.
+// https://developer.apple.com/documentation/appkit/nspasteboardtype?language=objc
+type NSPasteboardType = string
+
+/*
+Code to get the values for those constants:
+```objc
+//
+//  main.m
+//  test-objc
+//
+//  Created by Jonas Faber on 16.02.21.
+//
+
+#import <Foundation/Foundation.h>
+#import <AppKit/NSPasteboard.h>
+#import <AppKit/NSTextView.h>
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+
+        NSLog(@"NSPasteboardTypeURL:%@", NSPasteboardTypeURL);
+        NSLog(@"NSPasteboardTypeColor:%@", NSPasteboardTypeColor);
+        NSLog(@"NSPasteboardTypeFileURL:%@", NSPasteboardTypeFileURL);
+        NSLog(@"NSPasteboardTypeFont:%@", NSPasteboardTypeFont);
+        NSLog(@"NSPasteboardTypeHTML:%@", NSPasteboardTypeHTML);
+        NSLog(@"NSPasteboardTypeMultipleTextSelection:%@", NSPasteboardTypeMultipleTextSelection);
+        NSLog(@"NSPasteboardTypePDF:%@", NSPasteboardTypePDF);
+        NSLog(@"NSPasteboardTypePNG:%@", NSPasteboardTypePNG);
+        NSLog(@"NSPasteboardTypeRTF:%@", NSPasteboardTypeRTF);
+        NSLog(@"NSPasteboardTypeRTFD:%@", NSPasteboardTypeRTFD);
+        NSLog(@"NSPasteboardTypeRuler:%@", NSPasteboardTypeRuler);
+        NSLog(@"NSPasteboardTypeSound:%@", NSPasteboardTypeSound);
+        NSLog(@"NSPasteboardTypeString:%@", NSPasteboardTypeString);
+        NSLog(@"NSPasteboardTypeTabularText:%@", NSPasteboardTypeTabularText);
+        NSLog(@"NSPasteboardTypeTextFinderOptions:%@", NSPasteboardTypeTextFinderOptions);
+        NSLog(@"NSPasteboardTypeTIFF:%@", NSPasteboardTypeTIFF);
+    }
+    return 0;
+}
+```
+*/
+
+const (
+	// NSPasteboardTypeURL holds URL data for one file or resource.
+	NSPasteboardTypeURL = NSPasteboardType("public.url")
+	// NSPasteboardTypeColor holds color data.
+	NSPasteboardTypeColor = NSPasteboardType("com.apple.cocoa.pasteboard.color")
+	// NSPasteboardTypeFileURL holds a file URL.
+	NSPasteboardTypeFileURL = NSPasteboardType("public.file-url")
+	// NSPasteboardTypeFont holds font and character information.
+	NSPasteboardTypeFont = NSPasteboardType("com.apple.cocoa.pasteboard.character-formatting")
+	// NSPasteboardTypeHTML holds type for HTML content.
+	NSPasteboardTypeHTML = NSPasteboardType("public.html")
+	// NSPasteboardTypeMultipleTextSelection holds multiple text selection.
+	NSPasteboardTypeMultipleTextSelection = NSPasteboardType("com.apple.cocoa.pasteboard.multiple-text-selection")
+	// NSPasteboardTypePDF holds PDF data.
+	NSPasteboardTypePDF = NSPasteboardType("com.adobe.pdf")
+	// NSPasteboardTypePNG holds PNG image data.
+	NSPasteboardTypePNG = NSPasteboardType("public.png")
+	// NSPasteboardTypeRTF holds rich Text Format (RTF) data.
+	NSPasteboardTypeRTF = NSPasteboardType("public.rtf")
+	// NSPasteboardTypeRTFD holds RTFD formatted file contents.
+	NSPasteboardTypeRTFD = NSPasteboardType("com.apple.flat-rtfd")
+	// NSPasteboardTypeRuler holds paragraph formatting information.
+	NSPasteboardTypeRuler = NSPasteboardType("com.apple.cocoa.pasteboard.paragraph-formatting")
+	// NSPasteboardTypeSound holds sound data.
+	NSPasteboardTypeSound = NSPasteboardType("com.apple.cocoa.pasteboard.sound")
+	// NSPasteboardTypeString holds string data.
+	NSPasteboardTypeString = NSPasteboardType("public.utf8-plain-text")
+	// NSPasteboardTypeTabularText holds tab-separated fields of text.
+	NSPasteboardTypeTabularText = NSPasteboardType("public.utf8-tab-separated-values-text")
+	// NSPasteboardTypeTextFinderOptions holds type for the Find panel metadata property list.
+	NSPasteboardTypeTextFinderOptions = NSPasteboardType("com.apple.cocoa.pasteboard.find-panel-search-options")
+	// NSPasteboardTypeTIFF holds tag Image File Format (TIFF) data.
+	NSPasteboardTypeTIFF = NSPasteboardType("public.tiff")
+)
+
+type NSPasteboard struct {
+	objc.Object
+}
+
+// Wrapper for NSPasteboard
+// https://developer.apple.com/documentation/appkit/nspasteboard?language=objc
+var NSPasteboard_ = NSPasteboard{objc.Get("NSPasteboard")}
+
+// NSPasteboard_GeneralPasteboard is the shared pasteboard object to use for general content.
+// https://developer.apple.com/documentation/appkit/nspasteboard/1530091-generalpasteboard?language=objc
+func NSPasteboard_GeneralPasteboard() NSPasteboard {
+	return NSPasteboard{NSPasteboard_.Get("generalPasteboard")}
+}
+
+// ClearContents clears the existing contents of the pasteboard.
+// https://developer.apple.com/documentation/appkit/nspasteboard/1533599-clearcontents?language=objc
+func (pb NSPasteboard) ClearContents() {
+	pb.Send("clearContents")
+}
+
+// SetStringForType sets the given string as the representation for the specified type for the first item on the receiver.
+// https://developer.apple.com/documentation/appkit/nspasteboard/1528225-setstring?language=objc
+func (pb NSPasteboard) SetStringForType(s string, t NSPasteboardType) {
+	pb.Send("setString:forType:", core.NSString_FromString(s),  core.NSString_FromString(t))
+}
+// StringForType returns a concatenation of the strings for the specified type from all the items in the receiver that contain the type.
+// https://developer.apple.com/documentation/appkit/nspasteboard/1533566-stringfortype?language=objc
+func (pb NSPasteboard) StringForType(t NSPasteboardType) string {
+	return pb.Send("stringForType:",  core.NSString_FromString(t)).String()
+}

--- a/cocoa/NSPasteboard.go
+++ b/cocoa/NSPasteboard.go
@@ -14,7 +14,6 @@ Code to get the values for those constants:
 ```objc
 #import <Foundation/Foundation.h>
 #import <AppKit/NSPasteboard.h>
-#import <AppKit/NSTextView.h>
 
 int main(int argc, const char * argv[]) {
     @autoreleasepool {

--- a/cocoa/NSPasteboard_test.go
+++ b/cocoa/NSPasteboard_test.go
@@ -1,0 +1,20 @@
+package cocoa_test
+
+import (
+	"fmt"
+	"github.com/progrium/macdriver/cocoa"
+)
+
+func ExampleNSPasteboard(){
+	// get general pasteboard
+	gp := cocoa.NSPasteboard_GeneralPasteboard()
+
+
+	// clear pasteboard and write to pasteboard
+	gp.ClearContents()
+	gp.SetStringForType("test-content", cocoa.NSPasteboardTypeString)
+
+	// read data from pasteboard
+	fmt.Println(gp.StringForType(cocoa.NSPasteboardTypeString))
+	// Output: "test-content"
+}

--- a/cocoa/NSPasteboard_test.go
+++ b/cocoa/NSPasteboard_test.go
@@ -16,5 +16,5 @@ func ExampleNSPasteboard(){
 
 	// read data from pasteboard
 	fmt.Println(gp.StringForType(cocoa.NSPasteboardTypeString))
-	// Output: "test-content"
+	// Output: test-content
 }


### PR DESCRIPTION
This PR adds support for NSPasteboard. Currently it covers the basic read from and write to pasteboard operations.

I included the objc code that i used to get the constants as comment. If anyone knows how we can access them directly instead let me know. I would gladly replace it.

Also i did not include the constants `NSFileContentsPboardType`, `NSFindPanelSearchOptionsPboardType` Pasteboard types as they had different contents that i was not sure about.

In terms of testing, i use this as showcased in the example with string only for now and have not yet tested pictures or anything else.

Also i spend some time to get the original apple doc comments converted and linked in the relevant places. Not sure if we want to do this or not.
