### PR TITLE
autoreleasepool

### DIFF
--- a/objc/autoreleasepool.go
+++ b/objc/autoreleasepool.go
@@ -1,0 +1,14 @@
+package objc
+
+/*
+#cgo LDFLAGS: -lobjc -framework Foundation
+extern void objc_autoreleasePoolPop(void* pool);
+extern void* objc_autoreleasePoolPush(void);
+*/
+import "C"
+
+func AutoreleasePool(body func()) {
+	pool := C.objc_autoreleasePoolPush()
+	defer C.objc_autoreleasePoolPop(pool)
+	body()
+}

--- a/objc/autoreleasepool.go
+++ b/objc/autoreleasepool.go
@@ -6,8 +6,13 @@ extern void objc_autoreleasePoolPop(void* pool);
 extern void* objc_autoreleasePoolPush(void);
 */
 import "C"
+import "runtime"
 
 func AutoreleasePool(body func()) {
+	// ObjC autoreleasepools are thread-local, so we need the body to be locked to
+	// the same OS thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	pool := C.objc_autoreleasePoolPush()
 	defer C.objc_autoreleasePoolPop(pool)
 	body()

--- a/objc/autoreleasepool_test.go
+++ b/objc/autoreleasepool_test.go
@@ -1,0 +1,28 @@
+package objc
+
+import (
+	"testing"
+)
+
+type AutoreleaseDealloc struct {
+	Object       `objc:"AutoreleaseDealloc : NSObject"`
+	deallocCount int
+}
+
+func TestAutorelease(t *testing.T) {
+	c := NewClassFromStruct(AutoreleaseDealloc{})
+	deallocCount := 0
+	c.AddMethod("dealloc", func(o Object) {
+		deallocCount++
+		o.SendSuper("dealloc")
+	})
+	RegisterClass(c)
+
+	AutoreleasePool(func() {
+		dc := GetClass("AutoreleaseDealloc").Alloc().Init()
+		dc.Autorelease()
+	})
+	if deallocCount != 1 {
+		t.Errorf("expected dealloc to be called once, but got: %d", deallocCount)
+	}
+}


### PR DESCRIPTION
Implements `AutoreleasePool(func())` to run the body with an active
autoreleasepool.

There's a test to show that this calls `dealloc` on the object that has been
added to the autoreleasepool with `.Autorelease()`.

I'm posting this for discussion, but I want to explore #49 more before settling
on a solution here. Integrating with the Go GC to `release` objects
automatically would be much easier for Go developers, but then do we still want
them to have to manually manage the autoreleasepools around blocks of code?

Alternatively, I think we could wrap each `Send` with an autoreleasepool so that
after each external call to ObjC, we would free any additional memory allocated
before returning to Go. This seems like it should produce "correct" behavior,
but there may be cases where this is a bit heavy-weight and developers would
want direct control over when to free the memory.

Fixes #12
