### PR TITLE
add wrapper for managing Release with GC

### DIFF
--- a/objc/gc.go
+++ b/objc/gc.go
@@ -1,0 +1,17 @@
+package objc
+
+import "runtime"
+
+type gcReleased struct{ Object }
+
+// GCReleased returns a wrapped Object which will automatically call Release
+// when it is freed by the Go garbage collector.
+// Afterwards, the caller should treat the input as if it had called Release,
+// and use the returned Object instead.
+func GCReleased(obj Object) Object {
+	r := &gcReleased{obj}
+	runtime.SetFinalizer(r, func(r *gcReleased) {
+		r.Release()
+	})
+	return r
+}

--- a/objc/gc_test.go
+++ b/objc/gc_test.go
@@ -1,0 +1,40 @@
+package objc
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+type GCReleasedTest struct {
+	Object `objc:"GCReleasedTest : NSObject"`
+}
+
+func TestGCReleased(t *testing.T) {
+	c := NewClassFromStruct(GCReleasedTest{})
+	deallocCount := 0
+	c.AddMethod("dealloc", func(o Object) {
+		deallocCount++
+		o.SendSuper("dealloc")
+	})
+	RegisterClass(c)
+
+	o := GCReleased(GetClass("GCReleasedTest").Alloc().Init())
+	runtime.GC()
+	if deallocCount != 0 {
+		t.Errorf("did not expect dealloc to be called while object is still live, but got: %d", deallocCount)
+	}
+	runtime.KeepAlive(o)
+	// Call the GC multiple time if necessary to be sure it has a chance to free
+	// this memory.
+	for i := 0; i < 10; i++ {
+		runtime.GC()
+		if deallocCount > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if deallocCount != 1 {
+		t.Errorf("expected dealloc to be called once, but got: %d", deallocCount)
+	}
+}


### PR DESCRIPTION
Helper for #49 to wrap an `Object` that will be released when it is freed by the
Go garbage collector.
