### PR TITLE
prototype for calling msgSend directly with CGo

### DIFF
--- a/core/NSDictionary.go
+++ b/core/NSDictionary.go
@@ -1,8 +1,23 @@
 package core
 
 import (
+	"unsafe"
+
 	"github.com/progrium/macdriver/objc"
 )
+
+/*
+#cgo LDFLAGS: -lobjc
+#define __OBJC2__ 1
+#include <objc/message.h>
+
+int (* send_NSDictionary_count)(id self, SEL _cmd) = (int(*)(id,SEL))objc_msgSend;
+
+int NSDictionary_count(void *id) {
+	return send_NSDictionary_count(id, (void *) sel_registerName("count"));
+}
+*/
+import "C"
 
 type NSDictionary struct {
 	objc.Object
@@ -20,4 +35,9 @@ func NSDictionary_Init(valueKeys ...interface{}) NSDictionary {
 
 func (d NSDictionary) ObjectForKey(key objc.Object) objc.Object {
 	return d.Send("objectForKey:", key)
+}
+
+func (d NSDictionary) Count() int {
+	x := C.NSDictionary_count(unsafe.Pointer(d.Pointer()))
+	return int(x)
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,0 +1,17 @@
+package core_test
+
+import (
+	"testing"
+
+	"github.com/progrium/macdriver/core"
+)
+
+func TestNSDictionaryCGo(t *testing.T) {
+	k := core.NSString_FromString("key")
+	v := core.NSString_FromString("value")
+	d := core.NSDictionary_Init(k, v)
+	count := d.Count()
+	if count != 1 {
+		t.Errorf("expected count to be 1, but got: %d", count)
+	}
+}

--- a/objc/call.c
+++ b/objc/call.c
@@ -1,0 +1,12 @@
+// #cgo LDFLAGS: -lobjc
+#define __OBJC2__ 1
+#include <objc/message.h>
+#include "_cgo_export.h"
+
+void GoObjc_Invoke(id self, SEL _cmd, id invocation) {
+	goInvoke((void*)self, (void*)_cmd, (void*)invocation);
+}
+
+id GoObjc_MethodSignature(id self, SEL _cmd, SEL sel) {
+	return goMethodSignature((void*)self, (void*)_cmd, (void*)sel);
+}

--- a/objc/call.go
+++ b/objc/call.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2012 The 'objc' Package Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package objc
+
+/*
+#cgo LDFLAGS: -lobjc
+#define __OBJC2__ 1
+#include <objc/message.h>
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"log"
+	"reflect"
+	"unsafe"
+)
+
+// setIBOutletValue attempts to assign the Objective-C object represented
+// by 'value' to the field named 'name' in the Go struct represented by 'obj'.
+//
+// The function sends the 'retain' message to the Objective-C object represented
+// by 'value' if the assignment was successful.
+//
+// If the assignment operation fails, this function will raise a runtime panic.
+func setIBOutletValue(obj reflect.Value, name string, value Object) {
+	// Find an IBOutlet with the name keyName.
+	val := obj.Elem()
+	typ := val.Type()
+	fieldIdx := -1
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Tag.Get("objc") == "IBOutlet" && field.Type.Implements(objectInterfaceType) {
+			if field.Name == name {
+				fieldIdx = i
+				break
+			}
+		}
+	}
+
+	// If we couldn't find a matching field, simply panic.
+	// We should only run into this is there is a bug in the package.
+	if fieldIdx == -1 {
+		panic("objc: bad setter for IBOutlet field '" + name + "'")
+	}
+
+	fieldVal := val.Field(fieldIdx)
+	fieldVal.Set(reflect.ValueOf(value))
+	value.Retain()
+}
+
+//export goMethodSignature
+func goMethodSignature(self, cmd, selPtr unsafe.Pointer) unsafe.Pointer {
+	// if true {
+	// 	panic("asdfasdfasdf")
+	// }
+	sel := stringFromSelector(selPtr)
+	log.Printf("resolving %v", sel)
+
+	obj := object{ptr: uintptr(self)}
+
+	clsName := object{ptr: getObjectClass(obj).Pointer()}.className()
+	clsInfo := classMap[clsName]
+	method := clsInfo.MethodForSelector(sel)
+	if method == nil {
+		return nil
+	}
+	return unsafe.Pointer(newSignature(funcTypeInfo(method)))
+}
+
+//export goInvoke
+func goInvoke(self, cmd, invocation unsafe.Pointer) {
+	inv := ObjectPtr(uintptr(invocation))
+	// Or use "self" here?
+	obj := object{ptr: inv.Get("target").Pointer()}
+	sel := stringFromSelector(unsafe.Pointer(inv.Get("selector").Pointer()))
+
+	clsName := object{ptr: getObjectClass(obj).Pointer()}.className()
+	clsInfo := classMap[clsName]
+	method := clsInfo.MethodForSelector(sel)
+
+	// Check if we have an internal pointer set for this object.
+	// If not, make it happen.
+	internalPtr := obj.internalPointer()
+	if internalPtr == nil {
+		// Allocate the Go struct.
+		val := reflect.New(clsInfo.typ)
+		ptr := unsafe.Pointer(val.Pointer())
+		// Add a reference in the classInfo. This ensures we have
+		// a reference to our Go struct somewhere in Go land, which
+		// makes the garbage collector not collect it under our feet.
+		clsInfo.AddRef(ptr)
+		// Set the internalPointer so we can easily access
+		// the instance's Go struct pointer.
+		obj.setInternalPointer(ptr)
+		internalPtr = ptr
+		// Finally, update the Go struct's embedded objc.Object to
+		// point to the actual Objective-C instance.
+		structVal := val.Elem()
+		if structVal.Kind() == reflect.Struct {
+			objectVal := structVal.FieldByName("Object")
+			if objectVal.IsValid() {
+				objectVal.Set(reflect.ValueOf(obj))
+			}
+		}
+	}
+	objVal := reflect.NewAt(clsInfo.typ, internalPtr)
+
+	// Check if the invoked selector is a setter for IBOutlets.
+	if _, isSetter := clsInfo.setters[sel]; isSetter {
+		var valuePtr uintptr
+		inv.Send("getArgument:atIndex:", unsafe.Pointer(&valuePtr), 2)
+		keyName := sel[3:]                    // strip 'set'
+		keyName = keyName[0 : len(keyName)-1] // strip ':'
+		setIBOutletValue(objVal, keyName, object{ptr: valuePtr})
+		// TODO setReturnValue:?
+		return
+	}
+
+	// Our own internal override for setValue:forKey: in order
+	// to support key-value coding. (For IBOutlets on iOS)
+	if sel == "setValue:forKey:" && method == nil {
+		// We only support Object values, so fetching
+		// Ints here is OK.
+		var valuePtr, keyPtr uintptr
+		inv.Send("getArgument:atIndex:", unsafe.Pointer(&valuePtr), 2)
+		inv.Send("getArgument:atIndex:", unsafe.Pointer(&keyPtr), 3)
+
+		// We don't export any NSString-based functionality
+		// in package objc, except for the String() method
+		// on object.  It calls the object's decription method,
+		// which for NSStrings returns the string itself (or at
+		// least something that has been good enough for now!).
+		keyName := object{ptr: keyPtr}.String()
+
+		setIBOutletValue(objVal, keyName, object{ptr: valuePtr})
+		// TODO setReturnValue:?
+		return
+	}
+
+	// The default dealloc implementation. This is called
+	// if a class doesn't register its own custom dealloc
+	// method.
+	if sel == "dealloc" && method == nil {
+		clsInfo.RemoveRef(internalPtr)
+		obj.SendSuper("dealloc")
+		// TODO setReturnValue:?
+		return
+	}
+
+	methodVal := reflect.ValueOf(method)
+
+	// First argument should point to the Go method's proper receiver.
+	// That's stored in the internalPointer, so fetch that.
+	args := []reflect.Value{objVal}
+
+	// Take care of the rest of the arguments
+	mt := reflect.TypeOf(method)
+	for i := 1; i < mt.NumIn(); i++ {
+		fetchArg := func(p unsafe.Pointer) {
+			inv.Send("getArgument:atIndex:", p, i+1)
+		}
+		typ := mt.In(i)
+
+		if typ.Implements(objectInterfaceType) {
+			var obj object
+			fetchArg(unsafe.Pointer(&obj.ptr))
+			args = append(args, reflect.ValueOf(obj))
+			continue
+		} else if typ.Implements(selectorInterfaceType) {
+			var v uintptr
+			fetchArg(unsafe.Pointer(&v))
+			sel := selector(stringFromSelector(unsafe.Pointer(v)))
+			args = append(args, reflect.ValueOf(sel))
+			continue
+		}
+
+		switch typ.Kind() {
+		case reflect.Int:
+			var v int
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+		case reflect.Int8:
+			var v int8
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+		case reflect.Int16:
+			var v int16
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+		case reflect.Int32:
+			var v int32
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+		case reflect.Int64:
+			var v int64
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+
+		case reflect.Uint8:
+			var v uint8
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+		case reflect.Uint16:
+			var v uint16
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+		case reflect.Uint32:
+			var v uint32
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+		case reflect.Uint64:
+			var v uint64
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+		case reflect.Uintptr:
+			var v uintptr
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+
+		case reflect.Float32:
+			var v float32
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+		case reflect.Float64:
+			var v float64
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v))
+
+		case reflect.Bool:
+			var v int // FIXME what size should we decode bool into?
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.ValueOf(v != 0))
+
+		case reflect.Ptr:
+			panic("call: cannot pass pointer arguments")
+			// ptrAddr := unsafe.Pointer(uintptr(fetcher.Int()))
+			// args = append(args, reflect.NewAt(typ.Elem(), ptrAddr))
+
+		default:
+			panic("call: unhandled arg")
+		}
+	}
+
+	retVals := methodVal.Call(args)
+
+	// If a custom dealloc method has been registered, we
+	// still need to remove the reference to our Go struct
+	// pointer in order for the GC to kick in. Do that now.
+	if sel == "dealloc" {
+		clsInfo.RemoveRef(internalPtr)
+	}
+
+	// XXX does this exist in the Apple implementation, or just:
+	// https://github.com/microsoft/WinObjC/blob/ea3f7983803fa02309f974ff878b6c9ecc72c7c4/Frameworks/Foundation/NSMethodSignature.mm
+	// objc_sizeof_type(typeString)
+
+	if len(retVals) > 0 {
+		val := retVals[0]
+		switch val.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			panic("not implemented")
+			// return uintptr(val.Int())
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			panic("not implemented")
+			// return uintptr(val.Uint())
+		case reflect.Bool:
+			v := val.Bool()
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+			// if val.Bool() {
+			// 	return 1
+			// } else {
+			// 	return 0
+			// }
+		case reflect.Float32:
+			panic("not implemented")
+			// frame.xmm0 = uintptr(math.Float32bits(float32(val.Float())))
+			// return 1
+		case reflect.Float64:
+			panic("not implemented")
+			// frame.xmm0 = uintptr(math.Float64bits(val.Float()))
+			// return 1
+		case reflect.Interface:
+			panic("not implemented")
+			// if obj, ok := val.Interface().(Object); ok {
+			// 	return obj.Pointer()
+			// }
+			// panic("call: bad interface return value")
+		default:
+			panic("call: unknown return value")
+		}
+	}
+
+	return
+}

--- a/objc/call.go
+++ b/objc/call.go
@@ -53,9 +53,6 @@ func setIBOutletValue(obj reflect.Value, name string, value Object) {
 
 //export goMethodSignature
 func goMethodSignature(self, cmd, selPtr unsafe.Pointer) unsafe.Pointer {
-	// if true {
-	// 	panic("asdfasdfasdf")
-	// }
 	sel := stringFromSelector(selPtr)
 	log.Printf("resolving %v", sel)
 
@@ -65,6 +62,7 @@ func goMethodSignature(self, cmd, selPtr unsafe.Pointer) unsafe.Pointer {
 	clsInfo := classMap[clsName]
 	method := clsInfo.MethodForSelector(sel)
 	if method == nil {
+		// FIXME delegate to super class?
 		return nil
 	}
 	return unsafe.Pointer(newSignature(funcTypeInfo(method)))

--- a/objc/call.go
+++ b/objc/call.go
@@ -253,10 +253,6 @@ func goInvoke(self, cmd, invocation unsafe.Pointer) {
 		clsInfo.RemoveRef(internalPtr)
 	}
 
-	// XXX does this exist in the Apple implementation, or just:
-	// https://github.com/microsoft/WinObjC/blob/ea3f7983803fa02309f974ff878b6c9ecc72c7c4/Frameworks/Foundation/NSMethodSignature.mm
-	// objc_sizeof_type(typeString)
-
 	if len(retVals) > 0 {
 		val := retVals[0]
 		switch val.Kind() {

--- a/objc/call.go
+++ b/objc/call.go
@@ -234,9 +234,9 @@ func goInvoke(self, cmd, invocation unsafe.Pointer) {
 			args = append(args, reflect.ValueOf(v != 0))
 
 		case reflect.Ptr:
-			panic("call: cannot pass pointer arguments")
-			// ptrAddr := unsafe.Pointer(uintptr(fetcher.Int()))
-			// args = append(args, reflect.NewAt(typ.Elem(), ptrAddr))
+			var v uintptr
+			fetchArg(unsafe.Pointer(&v))
+			args = append(args, reflect.NewAt(typ.Elem(), unsafe.Pointer(v)))
 
 		default:
 			panic("call: unhandled arg")
@@ -259,28 +259,48 @@ func goInvoke(self, cmd, invocation unsafe.Pointer) {
 	if len(retVals) > 0 {
 		val := retVals[0]
 		switch val.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			panic("not implemented")
-			// return uintptr(val.Int())
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-			panic("not implemented")
-			// return uintptr(val.Uint())
+		case reflect.Int:
+			v := int(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+		case reflect.Int8:
+			v := int8(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+		case reflect.Int16:
+			v := int16(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+		case reflect.Int32:
+			v := int32(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+		case reflect.Int64:
+			v := int64(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+		case reflect.Uint:
+			v := uint(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+		case reflect.Uint8:
+			v := uint8(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+		case reflect.Uint16:
+			v := uint16(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+		case reflect.Uint32:
+			v := uint32(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+		case reflect.Uint64:
+			v := uint64(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
+		case reflect.Uintptr:
+			v := uintptr(val.Int())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
 		case reflect.Bool:
 			v := val.Bool()
 			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
-			// if val.Bool() {
-			// 	return 1
-			// } else {
-			// 	return 0
-			// }
 		case reflect.Float32:
-			panic("not implemented")
-			// frame.xmm0 = uintptr(math.Float32bits(float32(val.Float())))
-			// return 1
+			v := float32(val.Float())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
 		case reflect.Float64:
-			panic("not implemented")
-			// frame.xmm0 = uintptr(math.Float64bits(val.Float()))
-			// return 1
+			v := val.Float()
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
 		case reflect.Interface:
 			panic("not implemented")
 			// if obj, ok := val.Interface().(Object); ok {

--- a/objc/call.go
+++ b/objc/call.go
@@ -12,6 +12,7 @@ package objc
 */
 import "C"
 import (
+	"fmt"
 	"log"
 	"reflect"
 	"unsafe"
@@ -302,15 +303,14 @@ func goInvoke(self, cmd, invocation unsafe.Pointer) {
 			v := val.Float()
 			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
 		case reflect.Interface:
-			panic("not implemented")
-			// if obj, ok := val.Interface().(Object); ok {
-			// 	return obj.Pointer()
-			// }
-			// panic("call: bad interface return value")
+			obj, ok := val.Interface().(Object)
+			if !ok {
+				panic(fmt.Errorf("call: bad interface return value: %v", val.Type()))
+			}
+			v := uintptr(obj.Pointer())
+			inv.Send("setReturnValue:", uintptr(unsafe.Pointer(&v)))
 		default:
 			panic("call: unknown return value")
 		}
 	}
-
-	return
 }

--- a/objc/call_amd64.go
+++ b/objc/call_amd64.go
@@ -100,39 +100,6 @@ func methodCallTarget() unsafe.Pointer {
 	return unsafe.Pointer(&C.GoObjc_CallTargetFrameSetup)
 }
 
-// setIBOutletValue attempts to assign the Objective-C object represented
-// by 'value' to the field named 'name' in the Go struct represented by 'obj'.
-//
-// The function sends the 'retain' message to the Objective-C object represented
-// by 'value' if the assignment was successful.
-//
-// If the assignment operation fails, this function will raise a runtime panic.
-func setIBOutletValue(obj reflect.Value, name string, value Object) {
-	// Find an IBOutlet with the name keyName.
-	val := obj.Elem()
-	typ := val.Type()
-	fieldIdx := -1
-	for i := 0; i < typ.NumField(); i++ {
-		field := typ.Field(i)
-		if field.Tag.Get("objc") == "IBOutlet" && field.Type.Implements(objectInterfaceType) {
-			if field.Name == name {
-				fieldIdx = i
-				break
-			}
-		}
-	}
-
-	// If we couldn't find a matching field, simply panic.
-	// We should only run into this is there is a bug in the package.
-	if fieldIdx == -1 {
-		panic("objc: bad setter for IBOutlet field '" + name + "'")
-	}
-
-	fieldVal := val.Field(fieldIdx)
-	fieldVal.Set(reflect.ValueOf(value))
-	value.Retain()
-}
-
 //export goMethodCallEntryPoint
 func goMethodCallEntryPoint(p uintptr) uintptr {
 	frame := (*amd64frame)(unsafe.Pointer(p))

--- a/objc/call_test.go
+++ b/objc/call_test.go
@@ -48,6 +48,7 @@ func registerTestClass() {
 		c.AddMethod("callWithInt16:", (*SomeObject).CallWithInt16)
 		c.AddMethod("callWithInt8:", (*SomeObject).CallWithInt8)
 		c.AddMethod("callWithBool:", (*SomeObject).CallWithBool)
+		c.AddMethod("callReturnObject:", (*SomeObject).CallReturnObject)
 		RegisterClass(c)
 	})
 }
@@ -133,6 +134,10 @@ func (so *SomeObject) CallWithBool(val bool) {
 	}
 }
 
+func (so *SomeObject) CallReturnObject(o Object) Object {
+	return o
+}
+
 func TestSelectorObjectPassing(t *testing.T) {
 	registerTestClass()
 	so := GetClass("SomeObject").Send("alloc").Send("init")
@@ -215,4 +220,13 @@ func TestBoolPassing(t *testing.T) {
 	so := GetClass("SomeObject").Send("alloc").Send("init")
 	so.Send("setTesting:", t)
 	so.Send("callWithBool:", boolval)
+}
+
+func TestObjectReturn(t *testing.T) {
+	registerTestClass()
+	so := GetClass("SomeObject").Send("alloc").Send("init")
+	out := so.Send("callReturnObject:", so)
+	if out != so {
+		t.Errorf("expected to return the input object")
+	}
 }

--- a/objc/call_test.go
+++ b/objc/call_test.go
@@ -7,6 +7,7 @@ package objc
 import (
 	"sync"
 	"testing"
+	"unsafe"
 )
 
 type SomeObject struct {
@@ -51,8 +52,10 @@ func registerTestClass() {
 	})
 }
 
-func (so *SomeObject) SetTesting(t *testing.T) {
-	so.t = t
+// func (so *SomeObject) SetTesting(t *testing.T) {
+func (so *SomeObject) SetTesting(t uintptr) {
+	// FIXME
+	so.t = (*testing.T)(unsafe.Pointer(t))
 }
 
 func (so *SomeObject) CallWithObjectAndSelector(object Object, selector Selector) {

--- a/objc/call_test.go
+++ b/objc/call_test.go
@@ -230,3 +230,12 @@ func TestObjectReturn(t *testing.T) {
 		t.Errorf("expected to return the input object")
 	}
 }
+
+func TestObjectReturn2(t *testing.T) {
+	registerTestClass()
+	so := GetClass("SomeObject").Send("alloc").Send("init")
+	out := send2(so.Pointer(), "callReturnObject:", so)
+	if out != so.Pointer() {
+		t.Errorf("expected to return the input object")
+	}
+}

--- a/objc/class_test.go
+++ b/objc/class_test.go
@@ -41,11 +41,13 @@ func (gs *DynamicMethodStruct) Value() uint64 {
 }
 
 func TestDynamicMethod(t *testing.T) {
+	t.FailNow()
+
 	c := NewClassFromStruct(DynamicMethodStruct{})
 	c.AddMethod("setValue", (*DynamicMethodStruct).SetValue)
 	c.AddMethod("hasValue", (*DynamicMethodStruct).Value)
-	c.AddMethod("methodSignatureForSelector:", (*DynamicMethodStruct).MethodSignatureForSelector)
-	c.AddMethod("forwardInvocation:", (*DynamicMethodStruct).ForwardInvocation)
+	// c.AddMethod("methodSignatureForSelector:", (*DynamicMethodStruct).MethodSignatureForSelector)
+	// c.AddMethod("forwardInvocation:", (*DynamicMethodStruct).ForwardInvocation)
 	RegisterClass(c)
 
 	o := GetClass("DynamicMethodStruct").Send("alloc").Send("init")

--- a/objc/class_test.go
+++ b/objc/class_test.go
@@ -1,0 +1,57 @@
+package objc
+
+import (
+	"log"
+	"testing"
+	"unsafe"
+)
+
+type DynamicMethodStruct struct {
+	Object `objc:"DynamicMethodStruct : NSObject"`
+	value  uint64
+}
+
+func (gs *DynamicMethodStruct) SetValue() {
+	gs.value = 0xbadc0c0a
+}
+
+// - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector;
+func (gs *DynamicMethodStruct) MethodSignatureForSelector(selector uintptr) uintptr {
+	// sel := ObjectPtr(selector)
+	name := stringFromSelector(unsafe.Pointer(selector))
+	if name == "foo:" {
+		return newSignature("v@:@@")
+	}
+	log.Printf("methodSig for %v", name)
+	// gs.Send("doesNotRecognizeSelector:", selector)
+	return 0
+}
+
+// - (void)forwardInvocation:(NSInvocation *)anInvocation;
+func (gs *DynamicMethodStruct) ForwardInvocation(anInvocation uintptr) {
+	inv := ObjectPtr(anInvocation)
+	var arg0 int
+	inv.Send("getArgument:atIndex:", uintptr(unsafe.Pointer(&arg0)), 2)
+	log.Printf("forwardInvocation: %v", inv)
+	log.Printf("arg0: %v", arg0)
+}
+
+func (gs *DynamicMethodStruct) Value() uint64 {
+	return gs.value
+}
+
+func TestDynamicMethod(t *testing.T) {
+	c := NewClassFromStruct(DynamicMethodStruct{})
+	c.AddMethod("setValue", (*DynamicMethodStruct).SetValue)
+	c.AddMethod("hasValue", (*DynamicMethodStruct).Value)
+	c.AddMethod("methodSignatureForSelector:", (*DynamicMethodStruct).MethodSignatureForSelector)
+	c.AddMethod("forwardInvocation:", (*DynamicMethodStruct).ForwardInvocation)
+	RegisterClass(c)
+
+	o := GetClass("DynamicMethodStruct").Send("alloc").Send("init")
+	// out := o.Send("methodSignatureForSelector:", uintptr(RegisterSelector("foo:bar:")))
+	// t.Errorf("out: %v", out.Pointer())
+	o.Send("foo:", 42)
+	t.Fail()
+	// o.Send("blah:blah:")
+}

--- a/objc/class_test.go
+++ b/objc/class_test.go
@@ -41,7 +41,7 @@ func (gs *DynamicMethodStruct) Value() uint64 {
 }
 
 func TestDynamicMethod(t *testing.T) {
-	t.FailNow()
+	t.Skipf("FIXME")
 
 	c := NewClassFromStruct(DynamicMethodStruct{})
 	c.AddMethod("setValue", (*DynamicMethodStruct).SetValue)

--- a/objc/invoke.go
+++ b/objc/invoke.go
@@ -15,7 +15,10 @@ void (* send_NSInvocation_setTarget)(id self, SEL _cmd, id target) = (void(*)(id
 void (* send_NSInvocation_setSelector)(id self, SEL _cmd, SEL sel) = (void(*)(id,SEL,SEL))objc_msgSend;
 
 // - (void)setArgument:(void *)argumentLocation atIndex:(NSInteger)idx;
-// void (* send_setArgument)(id self, SEL _cmd, void *arg, NSInteger idx) = (void(*)(id,SEL,void*,NSInteger))objc_msgSend;
+void (* send_setArgument)(id self, SEL _cmd, void *arg, int idx) = (void(*)(id,SEL,void*,int))objc_msgSend;
+void setArgument(void *invocation, void *arg, int idx) {
+	send_setArgument(invocation, sel_registerName("setArgument:atIndex:"), arg, idx);
+}
 
 // - (void)invoke;
 void (* send_invoke)(id self, SEL _cmd) = (void(*)(id,SEL))objc_msgSend;
@@ -53,8 +56,16 @@ func newInvocation(target uintptr, selName string) uintptr {
 	return uintptr(C.nsInvocation(unsafe.Pointer(target), C.CString(selName)))
 }
 
+func setArgumentAtIndex(call uintptr, arg unsafe.Pointer, index int) {
+	C.setArgument(unsafe.Pointer(call), arg, C.int(index))
+}
+
 // TODO variant for calls with no return?
 // or just split into two calls?
 func invoke(call uintptr, dest unsafe.Pointer) {
 	C.invoke(unsafe.Pointer(call), dest)
+}
+
+func cstring(ptr uintptr) string {
+	return C.GoString((*C.char)(unsafe.Pointer(ptr)))
 }

--- a/objc/invoke.go
+++ b/objc/invoke.go
@@ -7,21 +7,23 @@ package objc
 
 // + (NSInvocation *)invocationWithMethodSignature:(NSMethodSignature *)sig;
 id (* send_NSInvocation_invocationWithMethodSignature)(Class cls, SEL _cmd, id sig) = (id(*)(Class,SEL,id))objc_msgSend;
-// + (NSMethodSignature *)signatureWithObjCTypes:(const char *)types;
+
 // - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector;
 id (* send_NSObject_methodSignatureForSelector)(id self, SEL _cmd, SEL aSelector) = (id(*)(id,SEL,SEL))objc_msgSend;
+
 void (* send_NSInvocation_setTarget)(id self, SEL _cmd, id target) = (void(*)(id,SEL,id))objc_msgSend;
 void (* send_NSInvocation_setSelector)(id self, SEL _cmd, SEL sel) = (void(*)(id,SEL,SEL))objc_msgSend;
 
 // - (void)setArgument:(void *)argumentLocation atIndex:(NSInteger)idx;
 // void (* send_setArgument)(id self, SEL _cmd, void *arg, NSInteger idx) = (void(*)(id,SEL,void*,NSInteger))objc_msgSend;
+
 // - (void)invoke;
 void (* send_invoke)(id self, SEL _cmd) = (void(*)(id,SEL))objc_msgSend;
-void (* send_invokeWithTarget)(id self, SEL _cmd,id) = (void(*)(id,SEL,id))objc_msgSend;
+
 // - (void)getReturnValue:(void *)retLoc;
 void (* send_getReturnValue)(id self, SEL _cmd, void *retLoc) = (void(*)(id,SEL,void*))objc_msgSend;
 
-void *cgoMethodSignatureForSelector(void *target, char *selName) {
+void *methodSignatureForSelector(void *target, char *selName) {
 	return send_NSObject_methodSignatureForSelector(target, sel_registerName("methodSignatureForSelector:"), sel_registerName(selName));
 }
 
@@ -37,18 +39,17 @@ void *nsInvocation(void *target, char *selName) {
 
 void invoke(void *invocation, void *retLoc) {
 	send_invoke(invocation, sel_registerName("invoke"));
-	// send_invokeWithTarget(invocation, sel_registerName("invoke"), target);
 	send_getReturnValue(invocation, sel_registerName("getReturnValue:"), retLoc);
 }
 */
 import "C"
 import "unsafe"
 
-func MethodSignatureForSelector(target uintptr, selName string) uintptr {
-	return uintptr(C.cgoMethodSignatureForSelector(unsafe.Pointer(target), C.CString(selName)))
+func methodSignatureForSelector(target uintptr, selName string) uintptr {
+	return uintptr(C.methodSignatureForSelector(unsafe.Pointer(target), C.CString(selName)))
 }
 
-func NewInvocation(target uintptr, selName string) uintptr {
+func newInvocation(target uintptr, selName string) uintptr {
 	return uintptr(C.nsInvocation(unsafe.Pointer(target), C.CString(selName)))
 }
 
@@ -57,7 +58,3 @@ func NewInvocation(target uintptr, selName string) uintptr {
 func invoke(call uintptr, dest unsafe.Pointer) {
 	C.invoke(unsafe.Pointer(call), dest)
 }
-
-// + (NSInvocation *)invocationWithMethodSignature:(NSMethodSignature *)sig;
-// + (NSMethodSignature *)signatureWithObjCTypes:(const char *)types;
-// - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector;

--- a/objc/invoke.go
+++ b/objc/invoke.go
@@ -69,3 +69,11 @@ func invoke(call uintptr, dest unsafe.Pointer) {
 func cstring(ptr uintptr) string {
 	return C.GoString((*C.char)(unsafe.Pointer(ptr)))
 }
+
+func send(retDest unsafe.Pointer, target uintptr, selName string, args ...unsafe.Pointer) {
+	inv := newInvocation(target, selName)
+	for i, arg := range args {
+		setArgumentAtIndex(inv, arg, i+2)
+	}
+	invoke(inv, retDest)
+}

--- a/objc/invoke.go
+++ b/objc/invoke.go
@@ -1,0 +1,63 @@
+package objc
+
+/*
+#cgo LDFLAGS: -lobjc
+#define __OBJC2__ 1
+#include <objc/message.h>
+
+// + (NSInvocation *)invocationWithMethodSignature:(NSMethodSignature *)sig;
+id (* send_NSInvocation_invocationWithMethodSignature)(Class cls, SEL _cmd, id sig) = (id(*)(Class,SEL,id))objc_msgSend;
+// + (NSMethodSignature *)signatureWithObjCTypes:(const char *)types;
+// - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector;
+id (* send_NSObject_methodSignatureForSelector)(id self, SEL _cmd, SEL aSelector) = (id(*)(id,SEL,SEL))objc_msgSend;
+void (* send_NSInvocation_setTarget)(id self, SEL _cmd, id target) = (void(*)(id,SEL,id))objc_msgSend;
+void (* send_NSInvocation_setSelector)(id self, SEL _cmd, SEL sel) = (void(*)(id,SEL,SEL))objc_msgSend;
+
+// - (void)setArgument:(void *)argumentLocation atIndex:(NSInteger)idx;
+// void (* send_setArgument)(id self, SEL _cmd, void *arg, NSInteger idx) = (void(*)(id,SEL,void*,NSInteger))objc_msgSend;
+// - (void)invoke;
+void (* send_invoke)(id self, SEL _cmd) = (void(*)(id,SEL))objc_msgSend;
+void (* send_invokeWithTarget)(id self, SEL _cmd,id) = (void(*)(id,SEL,id))objc_msgSend;
+// - (void)getReturnValue:(void *)retLoc;
+void (* send_getReturnValue)(id self, SEL _cmd, void *retLoc) = (void(*)(id,SEL,void*))objc_msgSend;
+
+void *cgoMethodSignatureForSelector(void *target, char *selName) {
+	return send_NSObject_methodSignatureForSelector(target, sel_registerName("methodSignatureForSelector:"), sel_registerName(selName));
+}
+
+void *nsInvocation(void *target, char *selName) {
+	Class cls = objc_getClass("NSInvocation");
+	SEL sel = sel_registerName(selName);
+	id sig = send_NSObject_methodSignatureForSelector(target, sel_registerName("methodSignatureForSelector:"), sel);
+	id inv = send_NSInvocation_invocationWithMethodSignature(cls, sel_registerName("invocationWithMethodSignature:"), sig);
+	send_NSInvocation_setTarget(inv, sel_registerName("setTarget:"), target);
+	send_NSInvocation_setSelector(inv, sel_registerName("setSelector:"), sel);
+	return inv;
+}
+
+void invoke(void *invocation, void *retLoc) {
+	send_invoke(invocation, sel_registerName("invoke"));
+	// send_invokeWithTarget(invocation, sel_registerName("invoke"), target);
+	send_getReturnValue(invocation, sel_registerName("getReturnValue:"), retLoc);
+}
+*/
+import "C"
+import "unsafe"
+
+func MethodSignatureForSelector(target uintptr, selName string) uintptr {
+	return uintptr(C.cgoMethodSignatureForSelector(unsafe.Pointer(target), C.CString(selName)))
+}
+
+func NewInvocation(target uintptr, selName string) uintptr {
+	return uintptr(C.nsInvocation(unsafe.Pointer(target), C.CString(selName)))
+}
+
+// TODO variant for calls with no return?
+// or just split into two calls?
+func invoke(call uintptr, dest unsafe.Pointer) {
+	C.invoke(unsafe.Pointer(call), dest)
+}
+
+// + (NSInvocation *)invocationWithMethodSignature:(NSMethodSignature *)sig;
+// + (NSMethodSignature *)signatureWithObjCTypes:(const char *)types;
+// - (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector;

--- a/objc/invoke_test.go
+++ b/objc/invoke_test.go
@@ -34,6 +34,14 @@ func TestInvocation(t *testing.T) {
 
 	i2 := newInvocation(sigID, "getArgumentTypeAtIndex:")
 	idx := 1
+	// this works, but may not be safe since this is holding onto a pointer to the Go memory
+	// unless it makes a copy?
+	// or pass everything we need into a single C call that performs the call and the releases it?
+	// or do alloc in C?
+	// maybe set retainArguments to make sure it makes a copy, and we can
+	// then manually "release" when we're done?
+	// Based on this it looks like it's copying the value into the target frame:
+	// https://github.com/microsoft/WinObjC/blob/ea3f7983803fa02309f974ff878b6c9ecc72c7c4/Frameworks/Foundation/_NSInvocation.x86.mm
 	setArgumentAtIndex(i2, unsafe.Pointer(&idx), 2)
 	var arg uintptr
 	invoke(i2, unsafe.Pointer(&arg))

--- a/objc/invoke_test.go
+++ b/objc/invoke_test.go
@@ -31,4 +31,11 @@ func TestInvocation(t *testing.T) {
 	t.Errorf("out: %v", out)
 	outObj := ObjectPtr(out)
 	t.Errorf("outObj: %v", outObj)
+
+	i2 := newInvocation(sigID, "getArgumentTypeAtIndex:")
+	idx := 1
+	setArgumentAtIndex(i2, unsafe.Pointer(&idx), 2)
+	var arg uintptr
+	invoke(i2, unsafe.Pointer(&arg))
+	t.Errorf("argType: %v", cstring(arg))
 }

--- a/objc/invoke_test.go
+++ b/objc/invoke_test.go
@@ -17,33 +17,24 @@ func TestInvocation(t *testing.T) {
 		},
 	}
 
-	obj := GetClass("NSValue").Send("valueWithRect:", rect)
-	sigID := methodSignatureForSelector(obj.Pointer(), "description")
+	var objID uintptr
+	send(unsafe.Pointer(&objID), GetClass("NSValue").Pointer(), "valueWithRect:", unsafe.Pointer(&rect))
 
-	sig := ObjectPtr(sigID)
-	t.Errorf("sel: %v", sig)
+	var out uintptr
+	send(unsafe.Pointer(&out), objID, "description")
+	actual := ObjectPtr(out).String()
+	expected := "NSRect: {{0, 0}, {500, 500}}"
+	if actual != expected {
+		t.Errorf("expected %v, but got: %v", expected, actual)
+	}
 
-	i := newInvocation(obj.Pointer(), "description")
-	var out uintptr = 1
-	t.Errorf("out: %v", out)
-	invoke(i, unsafe.Pointer(&out))
-
-	t.Errorf("out: %v", out)
-	outObj := ObjectPtr(out)
-	t.Errorf("outObj: %v", outObj)
-
-	i2 := newInvocation(sigID, "getArgumentTypeAtIndex:")
+	sigID := methodSignatureForSelector(objID, "description")
+	var argType uintptr
 	idx := 1
-	// this works, but may not be safe since this is holding onto a pointer to the Go memory
-	// unless it makes a copy?
-	// or pass everything we need into a single C call that performs the call and the releases it?
-	// or do alloc in C?
-	// maybe set retainArguments to make sure it makes a copy, and we can
-	// then manually "release" when we're done?
-	// Based on this it looks like it's copying the value into the target frame:
-	// https://github.com/microsoft/WinObjC/blob/ea3f7983803fa02309f974ff878b6c9ecc72c7c4/Frameworks/Foundation/_NSInvocation.x86.mm
-	setArgumentAtIndex(i2, unsafe.Pointer(&idx), 2)
-	var arg uintptr
-	invoke(i2, unsafe.Pointer(&arg))
-	t.Errorf("argType: %v", cstring(arg))
+	send(unsafe.Pointer(&argType), sigID, "getArgumentTypeAtIndex:", unsafe.Pointer(&idx))
+	actual = cstring(argType)
+	expected = ":" // arg 1 is a selector, encoded as a colon
+	if actual != expected {
+		t.Errorf("expected %v, but got: %v", expected, actual)
+	}
 }

--- a/objc/invoke_test.go
+++ b/objc/invoke_test.go
@@ -1,0 +1,45 @@
+package objc
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestInvocation(t *testing.T) {
+	rect := NSRect{
+		NSPoint{
+			X: 0,
+			Y: 0,
+		},
+		NSSize{
+			Width:  500,
+			Height: 500,
+		},
+	}
+
+	obj := GetClass("NSValue").Send("valueWithRect:", rect)
+	sigID := MethodSignatureForSelector(obj.Pointer(), "description")
+
+	sig := ObjectPtr(sigID)
+	t.Errorf("sel: %v", sig)
+
+	// inv := GetClass("NSInvocation").Send("invocationWithMethodSignature:", sig)
+	// inv.Set("target:", obj)
+	// inv.Set("selector:", GetSelector("description"))
+	i := NewInvocation(obj.Pointer(), "description")
+	inv := ObjectPtr(i)
+	t.Errorf("inv: %v", inv)
+	// inv.Send("invoke")
+	var out uintptr = 1
+	t.Errorf("out: %v", out)
+	invoke(i, unsafe.Pointer(&out))
+
+	// t.Errorf("i: %v", i)
+	// inv.Send("getReturnValue:", uintptr(unsafe.Pointer(&out)))
+	t.Errorf("out: %v", out)
+	outObj := ObjectPtr(out)
+	t.Errorf("outObj: %v", outObj)
+	// utf8Bytes := outObj.Send("UTF8String")
+	// s := C.GoString((*C.char)(unsafe.Pointer(utf8Bytes.Pointer())))
+
+}

--- a/objc/invoke_test.go
+++ b/objc/invoke_test.go
@@ -18,28 +18,17 @@ func TestInvocation(t *testing.T) {
 	}
 
 	obj := GetClass("NSValue").Send("valueWithRect:", rect)
-	sigID := MethodSignatureForSelector(obj.Pointer(), "description")
+	sigID := methodSignatureForSelector(obj.Pointer(), "description")
 
 	sig := ObjectPtr(sigID)
 	t.Errorf("sel: %v", sig)
 
-	// inv := GetClass("NSInvocation").Send("invocationWithMethodSignature:", sig)
-	// inv.Set("target:", obj)
-	// inv.Set("selector:", GetSelector("description"))
-	i := NewInvocation(obj.Pointer(), "description")
-	inv := ObjectPtr(i)
-	t.Errorf("inv: %v", inv)
-	// inv.Send("invoke")
+	i := newInvocation(obj.Pointer(), "description")
 	var out uintptr = 1
 	t.Errorf("out: %v", out)
 	invoke(i, unsafe.Pointer(&out))
 
-	// t.Errorf("i: %v", i)
-	// inv.Send("getReturnValue:", uintptr(unsafe.Pointer(&out)))
 	t.Errorf("out: %v", out)
 	outObj := ObjectPtr(out)
 	t.Errorf("outObj: %v", outObj)
-	// utf8Bytes := outObj.Send("UTF8String")
-	// s := C.GoString((*C.char)(unsafe.Pointer(utf8Bytes.Pointer())))
-
 }

--- a/objc/msg_amd64.go
+++ b/objc/msg_amd64.go
@@ -155,7 +155,7 @@ func sendMsg(obj Object, sendFuncName string, selector string, args ...interface
 		default:
 			val := reflect.ValueOf(args[i])
 			switch val.Kind() {
-			case reflect.Ptr:
+			case reflect.Ptr, reflect.UnsafePointer:
 				intArgs = append(intArgs, val.Pointer())
 			case reflect.Uintptr:
 				intArgs = append(intArgs, uintptr(val.Uint()))

--- a/objc/msg_amd64.go
+++ b/objc/msg_amd64.go
@@ -231,6 +231,7 @@ func sendMsg(obj Object, sendFuncName string, selector string, args ...interface
 }
 
 func (obj object) Send(selector string, args ...interface{}) Object {
+	// return ObjectPtr(send2(obj.Pointer(), selector, args...))
 	return sendMsg(obj, "objc_msgSend", selector, args...)
 }
 

--- a/objc/selector.go
+++ b/objc/selector.go
@@ -22,7 +22,10 @@ char *GoObjc_SelectorToString(void *sel) {
 }
 */
 import "C"
-import "unsafe"
+import (
+	"strings"
+	"unsafe"
+)
 
 // A Selector represents an Objective-C method selector.
 type Selector interface {
@@ -80,9 +83,14 @@ func stringFromSelector(sel unsafe.Pointer) string {
 // typeInfoForMethod returns the type encoding string for
 // selector on obj's Class.
 func typeInfoForMethod(obj Object, selector string) string {
-	sel := selectorWithName(selector)
-	cls := getObjectClass(obj)
-	return C.GoString(C.GoObjc_TypeInfoForMethod(unsafe.Pointer(cls.Pointer()), sel))
+	sig := methodSignatureForSelector(obj.Pointer(), selector)
+	nargs := numberOfArguments(sig)
+	sigParts := make([]string, nargs+1)
+	sigParts[0] = methodReturnType(sig)
+	for i := 0; i < nargs; i++ {
+		sigParts[i+1] = getArgumentTypeAtIndex(sig, i)
+	}
+	return strings.Join(sigParts, "")
 }
 
 // simplifyTypeInfo returns a simplified typeInfo representation

--- a/objc/struct_test.go
+++ b/objc/struct_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 type NSPoint struct {
-	X float32
-	Y float32
+	X float64
+	Y float64
 }
 
 type NSSize struct {
-	Width  float32
-	Height float32
+	Width  float64
+	Height float64
 }
 
 type NSRect struct {

--- a/objc/typeinfo_amd64.go
+++ b/objc/typeinfo_amd64.go
@@ -31,7 +31,7 @@ func typeInfoForType(typ reflect.Type) string {
 	case reflect.Int32:
 		return encInt
 	case reflect.Int64:
-		return encULong
+		return encLongLong
 	case reflect.Uint:
 		return encUInt
 	case reflect.Uint8:
@@ -41,17 +41,20 @@ func typeInfoForType(typ reflect.Type) string {
 	case reflect.Uint32:
 		return encUInt
 	case reflect.Uint64:
-		return encULong
-	case reflect.Uintptr:
-		// return encPtr
-		return encULong
+		return encULongLong
 	case reflect.Float32:
 		return encFloat
 	case reflect.Float64:
 		return encDouble
+
+	// For pointers we need to specify what type they're pointing to.
+	// Though for the sake of argument passing the element type doesn't change
+	// the size of the pointer itself. So we use `long long` as an arbitrary type
+	// so that we can use these in initializing the NSMethodSignature.
+	case reflect.Uintptr:
+		return encPtr + encLongLong
 	case reflect.Ptr:
-		panic("not supported")
-		// return encPtr
+		return encPtr + encLongLong
 	}
 
 	panic("typeinfo: unhandled/invalid kind " + fmt.Sprintf("%v", kind) + " " + fmt.Sprintf("%v", typ))

--- a/objc/typeinfo_amd64.go
+++ b/objc/typeinfo_amd64.go
@@ -43,13 +43,15 @@ func typeInfoForType(typ reflect.Type) string {
 	case reflect.Uint64:
 		return encULong
 	case reflect.Uintptr:
-		return encPtr
+		// return encPtr
+		return encULong
 	case reflect.Float32:
 		return encFloat
 	case reflect.Float64:
 		return encDouble
 	case reflect.Ptr:
-		return encPtr
+		panic("not supported")
+		// return encPtr
 	}
 
 	panic("typeinfo: unhandled/invalid kind " + fmt.Sprintf("%v", kind) + " " + fmt.Sprintf("%v", typ))


### PR DESCRIPTION
This is a quick sketch of a possible alternative approach for sending messages.

This is based on Apple's example for creating type-safe pointers to `objc_msgSend`:
https://developer.apple.com/documentation/apple-silicon/addressing-architectural-differences-in-your-macos-code#Enable-Strict-Type-Enforcement-for-Dynamic-Method-Dispatching

If we're planning on generating the Go wrappers based on the API, we could
generate the CGo code too to more closely follow what the Obj-C pre-processor
is doing for tranlating method calls to C code.

This should work for compiling on ARM for #5 though I haven't tested that out
yet since it just depends on the C compiler, and not custom assembly to
invoke the function for each platform.

Though that would mean that users wanting to send message by name would also
need to provide CGo code (or use a code generator we provide) instead of
calling `Send(msg, args...)`.

But I wanted to get something up to discuss, since if we go this route it would
affect other things like #49 where we'd move more logic into the code generator
instead of the runtime reflection-style code in `Send`.
