### PR TITLE
Optimize sendMsg

### DIFF
--- a/internal/objctest/core.go
+++ b/internal/objctest/core.go
@@ -1,0 +1,72 @@
+package objctest
+
+import "unsafe"
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation
+
+#import <Foundation/Foundation.h>
+
+void * numWithBool      (bool v)               { return [NSNumber numberWithBool:v];             }
+void * numWithChar      (signed char v)        { return [NSNumber numberWithChar:v];             }
+void * numWithShort     (signed short v)       { return [NSNumber numberWithShort:v];            }
+void * numWithInt       (signed int v)         { return [NSNumber numberWithInt:v];              }
+void * numWithLongLong  (signed long long v)   { return [NSNumber numberWithLongLong:v];         }
+void * numWithUChar     (unsigned char v)      { return [NSNumber numberWithUnsignedChar:v];     }
+void * numWithUShort    (unsigned short v)     { return [NSNumber numberWithUnsignedShort:v];    }
+void * numWithUInt      (unsigned int v)       { return [NSNumber numberWithUnsignedInt:v];      }
+void * numWithULongLong (unsigned long long v) { return [NSNumber numberWithUnsignedLongLong:v]; }
+void * numWithFloat     (float v)              { return [NSNumber numberWithFloat:v];            }
+void * numWithDouble    (double v)             { return [NSNumber numberWithDouble:v];           }
+
+bool               numBoolValue      (void * num) { return [(NSNumber *)num boolValue];             }
+signed char        numCharValue      (void * num) { return [(NSNumber *)num charValue];             }
+signed short       numShortValue     (void * num) { return [(NSNumber *)num shortValue];            }
+signed int         numIntValue       (void * num) { return [(NSNumber *)num intValue];              }
+signed long long   numLongLongValue  (void * num) { return [(NSNumber *)num longLongValue];         }
+unsigned char      numUCharValue     (void * num) { return [(NSNumber *)num unsignedCharValue];     }
+unsigned short     numUShortValue    (void * num) { return [(NSNumber *)num unsignedShortValue];    }
+unsigned int       numUIntValue      (void * num) { return [(NSNumber *)num unsignedIntValue];      }
+unsigned long long numULongLongValue (void * num) { return [(NSNumber *)num unsignedLongLongValue]; }
+float              numFloatValue     (void * num) { return [(NSNumber *)num floatValue];            }
+double             numDoubleValue    (void * num) { return [(NSNumber *)num doubleValue];           }
+
+void * stringWith(const char * c) { return [NSString stringWithUTF8String:c]; }
+const char * stringValue(void * str) { return [(NSString *)str UTF8String]; }
+*/
+import "C"
+
+func NSNumberWithBool(v bool) unsafe.Pointer       { return C.numWithBool(C.bool(v)) }
+func NSNumberWithInt8(v int8) unsafe.Pointer       { return C.numWithChar(C.schar(v)) }
+func NSNumberWithInt16(v int16) unsafe.Pointer     { return C.numWithShort(C.short(v)) }
+func NSNumberWithInt32(v int32) unsafe.Pointer     { return C.numWithInt(C.int(v)) }
+func NSNumberWithInt64(v int64) unsafe.Pointer     { return C.numWithLongLong(C.longlong(v)) }
+func NSNumberWithUint8(v uint8) unsafe.Pointer     { return C.numWithUChar(C.uchar(v)) }
+func NSNumberWithUint16(v uint16) unsafe.Pointer   { return C.numWithUShort(C.ushort(v)) }
+func NSNumberWithUint32(v uint32) unsafe.Pointer   { return C.numWithUInt(C.uint(v)) }
+func NSNumberWithUint64(v uint64) unsafe.Pointer   { return C.numWithULongLong(C.ulonglong(v)) }
+func NSNumberWithFloat32(v float32) unsafe.Pointer { return C.numWithFloat(C.float(v)) }
+func NSNumberWithFloat64(v float64) unsafe.Pointer { return C.numWithDouble(C.double(v)) }
+
+func NSNumberBoolValue(v unsafe.Pointer) bool       { return bool(C.numBoolValue(v)) }
+func NSNumberInt8Value(v unsafe.Pointer) int8       { return int8(C.numCharValue(v)) }
+func NSNumberInt16Value(v unsafe.Pointer) int16     { return int16(C.numShortValue(v)) }
+func NSNumberInt32Value(v unsafe.Pointer) int32     { return int32(C.numIntValue(v)) }
+func NSNumberInt64Value(v unsafe.Pointer) int64     { return int64(C.numLongLongValue(v)) }
+func NSNumberUint8Value(v unsafe.Pointer) uint8     { return uint8(C.numUCharValue(v)) }
+func NSNumberUint16Value(v unsafe.Pointer) uint16   { return uint16(C.numUShortValue(v)) }
+func NSNumberUint32Value(v unsafe.Pointer) uint32   { return uint32(C.numUIntValue(v)) }
+func NSNumberUint64Value(v unsafe.Pointer) uint64   { return uint64(C.numULongLongValue(v)) }
+func NSNumberFloat32Value(v unsafe.Pointer) float32 { return float32(C.numFloatValue(v)) }
+func NSNumberFloat64Value(v unsafe.Pointer) float64 { return float64(C.numDoubleValue(v)) }
+
+func NSStringWith(v string) unsafe.Pointer {
+	c := C.CString(v)
+	defer C.free(unsafe.Pointer(c))
+	return C.stringWith(c)
+}
+
+func NSStringValue(v unsafe.Pointer) string {
+	return C.GoString(C.stringValue(v))
+}

--- a/misc/variadic/functions.go
+++ b/misc/variadic/functions.go
@@ -1,0 +1,83 @@
+package variadic
+
+import "unsafe"
+
+/*
+#cgo LDFLAGS: -lobjc
+#import <objc/message.h>
+void * addr_msgSend = &objc_msgSend;
+void * addr_msgSendSuper = &objc_msgSendSuper;
+void * addr_msgSend_stret = &objc_msgSend_stret;
+void * addr_msgSendSuper_stret = &objc_msgSendSuper_stret;
+*/
+import "C"
+
+type Function int
+
+const (
+	F_msgSend Function = iota
+	F_msgSendSuper
+	F_msgSend_stret
+	F_msgSendSuper_stret
+)
+
+func (f Function) String() string {
+	switch f {
+	case F_msgSend:
+		return "objc_msgSend"
+	case F_msgSendSuper:
+		return "objc_msgSendSuper"
+	case F_msgSend_stret:
+		return "objc_msgSend_stret"
+	case F_msgSendSuper_stret:
+		return "objc_msgSendSuper_stret"
+	}
+	panic("unknown function")
+}
+
+func (f Function) IsSuper() bool {
+	switch f {
+	case F_msgSendSuper, F_msgSendSuper_stret:
+		return true
+	default:
+		return false
+	}
+}
+
+func (f Function) IsStRet() bool {
+	switch f {
+	case F_msgSend_stret, F_msgSendSuper_stret:
+		return true
+	default:
+		return false
+	}
+}
+
+func (f Function) StRet() Function {
+	switch f {
+	case F_msgSend:
+		return F_msgSend_stret
+	case F_msgSendSuper:
+		return F_msgSendSuper_stret
+	default:
+		return f
+	}
+}
+
+func (f Function) Addr() unsafe.Pointer {
+	switch f {
+	case F_msgSend:
+		return C.addr_msgSend
+	case F_msgSendSuper:
+		return C.addr_msgSendSuper
+	case F_msgSend_stret:
+		return C.addr_msgSend_stret
+	case F_msgSendSuper_stret:
+		return C.addr_msgSendSuper_stret
+	}
+	panic("unknown function")
+}
+
+func (f Function) NewCall() *FunctionCall {
+	return NewFunctionCallAddr(f.Addr())
+}

--- a/objc/msg_test.go
+++ b/objc/msg_test.go
@@ -1,0 +1,207 @@
+package objc
+
+import (
+	"math"
+	"math/rand"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/progrium/macdriver/internal/objctest"
+	"github.com/progrium/macdriver/misc/variadic"
+)
+
+func TestMain(m *testing.M) {
+	pool := GetClass("NSAutoreleasePool").Alloc().Init()
+	defer pool.Release()
+
+	os.Exit(m.Run())
+}
+
+func BenchmarkSendMsg(b *testing.B) {
+	obj := Get("NSObject").Send("new")
+	defer obj.Release()
+
+	for i := 0; i < b.N; i++ {
+		sendMsg(obj, variadic.F_msgSend, "description")
+	}
+}
+
+func TestNSStringSendMsg(t *testing.T) {
+	cases := []string{
+		"",
+		"Hello world!",
+		"foobar",
+	}
+
+	t.Run("C2Go", func(t *testing.T) {
+		for _, v := range cases {
+			t.Run("", func(t *testing.T) {
+				o := objctest.NSStringWith(v)
+				u := ObjectPtr(uintptr(o)).Send("UTF8String").CString()
+
+				if v != u {
+					t.Fatalf("expected %q, got %q", v, u)
+				}
+			})
+		}
+	})
+
+	t.Run("Go2C", func(t *testing.T) {
+		t.Skip("Send can't handle strings")
+		for _, v := range cases {
+			t.Run("", func(t *testing.T) {
+				o := Get("NSString").Send("stringWithUTF8String:", v)
+				u := objctest.NSStringValue(unsafe.Pointer(o.Pointer()))
+
+				if v != u {
+					t.Fatalf("expected %q, got %q", v, u)
+				}
+			})
+		}
+	})
+
+	t.Run("Go2Go", func(t *testing.T) {
+		t.Skip("Send can't handle strings")
+		for _, v := range cases {
+			t.Run("", func(t *testing.T) {
+				u := Get("NSString").Send("stringWithUTF8String:", v).Send("UTF8String").String()
+
+				if v != u {
+					t.Fatalf("expected %q, got %q", v, u)
+				}
+			})
+		}
+	})
+}
+
+func TestNSNumberSendMsg(t *testing.T) {
+	const N = 100
+
+	type Case struct {
+		name    string
+		value   func() interface{}
+		numWith interface{}
+		obj2go  interface{}
+		numVal  interface{}
+	}
+
+	cases := []Case{
+		{"Bool", func() interface{} { return rand.Intn(2) != 0 }, objctest.NSNumberWithBool, Object.Bool, objctest.NSNumberBoolValue},
+		{"Char", func() interface{} { return int8(rand.Int63()) }, objctest.NSNumberWithInt8, Object.Int, objctest.NSNumberInt8Value},
+		{"Short", func() interface{} { return int16(rand.Int63()) }, objctest.NSNumberWithInt16, Object.Int, objctest.NSNumberInt16Value},
+		{"Int", func() interface{} { return int32(rand.Int63()) }, objctest.NSNumberWithInt32, Object.Int, objctest.NSNumberInt32Value},
+		{"LongLong", func() interface{} { return int64(rand.Int63()) }, objctest.NSNumberWithInt64, Object.Int, objctest.NSNumberInt64Value},
+		{"UnsignedChar", func() interface{} { return uint8(rand.Uint64()) }, objctest.NSNumberWithUint8, Object.Uint, objctest.NSNumberUint8Value},
+		{"UnsignedShort", func() interface{} { return uint16(rand.Uint64()) }, objctest.NSNumberWithUint16, Object.Uint, objctest.NSNumberUint16Value},
+		{"UnsignedInt", func() interface{} { return uint32(rand.Uint64()) }, objctest.NSNumberWithUint32, Object.Uint, objctest.NSNumberUint32Value},
+		{"UnsignedLongLong", func() interface{} { return uint64(rand.Uint64()) }, objctest.NSNumberWithUint64, Object.Uint, objctest.NSNumberUint64Value},
+		{"Float", func() interface{} { return float32(rand.Float32()) }, objctest.NSNumberWithFloat32, Object.Float, objctest.NSNumberFloat32Value},
+		{"Double", func() interface{} { return float64(rand.Float64()) }, objctest.NSNumberWithFloat64, Object.Float, objctest.NSNumberFloat64Value},
+	}
+
+	floatCases := map[string]float64{
+		"Zero":   0,
+		"NaN":    math.NaN(),
+		"PosInf": math.Inf(+1),
+		"NegInf": math.Inf(-1),
+	}
+
+	runFloat := func(run func(Case), v float64) {
+		run(Case{"Double", func() interface{} { return v }, objctest.NSNumberWithFloat64, Object.Float, objctest.NSNumberFloat64Value})
+	}
+
+	selValue := func(c Case) string { return strings.ToLower(c.name[:1]) + c.name[1:] + "Value" }
+	selWith := func(c Case) string { return "numberWith" + c.name + ":" }
+
+	t.Run("C2Go", func(t *testing.T) {
+		run := func(c Case) {
+			numWith := reflect.ValueOf(c.numWith)
+			obj2go := reflect.ValueOf(c.obj2go)
+
+			v := reflect.ValueOf(c.value())
+			ptr := numWith.Call([]reflect.Value{v})[0]
+			ret := ObjectPtr(ptr.Pointer()).Send(selValue(c))
+			u := obj2go.Call([]reflect.Value{reflect.ValueOf(ret)})[0]
+
+			u = u.Convert(v.Type())
+			if reflect.DeepEqual(v, u) {
+				t.Fatalf("expected %v, got %v", v, u)
+			}
+		}
+
+		for _, c := range cases {
+			t.Run("", func(t *testing.T) {
+				for i := 0; i < N; i++ {
+					run(c)
+				}
+			})
+		}
+
+		for name, v := range floatCases {
+			t.Run("Float"+name, func(t *testing.T) {
+				runFloat(run, v)
+			})
+		}
+	})
+
+	t.Run("Go2C", func(t *testing.T) {
+		run := func(c Case) {
+			numVal := reflect.ValueOf(c.numVal)
+
+			v := reflect.ValueOf(c.value())
+			o := Get("NSNumber").Send(selWith(c), v.Interface())
+			u := numVal.Call([]reflect.Value{reflect.ValueOf(unsafe.Pointer(o.Pointer()))})[0]
+
+			u = u.Convert(v.Type())
+			if reflect.DeepEqual(v, u) {
+				t.Fatalf("expected %v, got %v", v, u)
+			}
+		}
+
+		for _, c := range cases {
+			t.Run("", func(t *testing.T) {
+				for i := 0; i < N; i++ {
+					run(c)
+				}
+			})
+		}
+
+		for name, v := range floatCases {
+			t.Run("Float"+name, func(t *testing.T) {
+				runFloat(run, v)
+			})
+		}
+	})
+
+	t.Run("Go2Go", func(t *testing.T) {
+		run := func(c Case) {
+			obj2go := reflect.ValueOf(c.obj2go)
+
+			v := reflect.ValueOf(c.value())
+			ret := Get("NSNumber").Send(selWith(c), v.Interface()).Send(selValue(c))
+			u := obj2go.Call([]reflect.Value{reflect.ValueOf(ret)})[0]
+
+			u = u.Convert(v.Type())
+			if reflect.DeepEqual(v, u) {
+				t.Fatalf("expected %v, got %v", v, u)
+			}
+		}
+
+		for _, c := range cases {
+			t.Run("", func(t *testing.T) {
+				for i := 0; i < N; i++ {
+					run(c)
+				}
+			})
+		}
+
+		for name, v := range floatCases {
+			t.Run("Float"+name, func(t *testing.T) {
+				runFloat(run, v)
+			})
+		}
+	})
+}


### PR DESCRIPTION
This PR:

- Caches `simpleTypeInfoForMethod`
- Changes the parameter `sendFuncName string` of `sendMsg` to an pseudo-enumeration
- Adds tests to ensure C-to-Go, Go-to-C, and Go-to-C-to-Go handling of numeric types works properly.
- Add `Object.CString() string`, which interprets the pointer as a C string (I use this for tests)

This is a draft, because I haven't updated the 32-bit version. Go does not support darwin/386, so if I did update the 32-bit version, I wouldn't be able to build it. I'd like to remove 32-bit support: #62.