### PR TITLE
Cache string<->selector to reduce CGo calls

### DIFF
--- a/objc/msg_amd64.go
+++ b/objc/msg_amd64.go
@@ -80,7 +80,7 @@ func sendMsg(obj Object, sendFunc variadic.Function, selector string, args ...in
 	memArgs := []uintptr{}
 	argOffset := 2 // self, op
 
-	typeInfo := simpleTypeInfoForMethod(obj, selector)
+	typeInfo := simpleTypeInfoForMethod(obj, sel)
 
 	var stretAddr uintptr
 	if len(typeInfo) > 0 && string(typeInfo[0]) == encStructBegin {


### PR DESCRIPTION
This caches the conversion from selector name to pointer and vice versa, which reduces the number of CGo calls an application makes. This improves performance, as CGo calls are rather expensive.