### PR TITLE
fix IBOutlet types in NSViewController

### DIFF
--- a/api/appkit/nsviewcontroller.objc.json
+++ b/api/appkit/nsviewcontroller.objc.json
@@ -551,15 +551,17 @@
         "TopicURL": "https://developer.apple.com/documentation/appkit/nsviewcontroller/1434472-nibname?language=objc"
       },
       {
-        "Name": "NSView",
+        "Name": "view",
         "Description": "The view controller’s primary view.",
         "Declaration": "@property(strong) IBOutlet NSView *view;",
         "Type": {
-          "Name": "IBOutlet"
+          "Name": "NSView",
+          "IsPtr": true
         },
         "Attrs": {
           "strong": true
         },
+        "IsOutlet": true,
         "TopicURL": "https://developer.apple.com/documentation/appkit/nsviewcontroller/1434401-view?language=objc"
       },
       {
@@ -735,20 +737,22 @@
         "TopicURL": "https://developer.apple.com/documentation/appkit/nsviewcontroller/1434418-preferredminimumsize?language=objc"
       },
       {
-        "Name": "NSView",
+        "Name": "sourceItemView",
         "Description": "",
         "Declaration": "@property(strong) IBOutlet NSView *sourceItemView;",
         "Type": {
-          "Name": "IBOutlet"
+          "Name": "NSView",
+          "IsPtr": true
         },
         "Attrs": {
           "strong": true
         },
+        "IsOutlet": true,
         "TopicURL": "https://developer.apple.com/documentation/appkit/nsviewcontroller/1434479-sourceitemview?language=objc"
       }
     ]
   },
   "Kind": "class",
-  "PullDate": "2021-09-20T09:55:16.168739-07:00",
+  "PullDate": "2021-10-13T14:49:31.526935-07:00",
   "Version": 2
 }

--- a/cocoa/cocoa_objc.gen.go
+++ b/cocoa/cocoa_objc.gen.go
@@ -3233,6 +3233,16 @@ void* NSViewController_inst_nibBundle(void *id) {
 		nibBundle];
 }
 
+void* NSViewController_inst_view(void *id) {
+	return [(NSViewController*)id
+		view];
+}
+
+void NSViewController_inst_setView_(void *id, void* value) {
+	[(NSViewController*)id
+		setView: value];
+}
+
 void* NSViewController_inst_title(void *id) {
 	return [(NSViewController*)id
 		title];
@@ -3301,6 +3311,16 @@ NSSize NSViewController_inst_preferredMaximumSize(void *id) {
 NSSize NSViewController_inst_preferredMinimumSize(void *id) {
 	return [(NSViewController*)id
 		preferredMinimumSize];
+}
+
+void* NSViewController_inst_sourceItemView(void *id) {
+	return [(NSViewController*)id
+		sourceItemView];
+}
+
+void NSViewController_inst_setSourceItemView_(void *id, void* value) {
+	[(NSViewController*)id
+		setSourceItemView: value];
 }
 
 void NSVisualEffectView_inst_viewDidMoveToWindow(void *id) {
@@ -13667,6 +13687,26 @@ func (x gen_NSViewController) NibBundle() (
 	return
 }
 
+func (x gen_NSViewController) View() (
+	r0 NSView,
+) {
+	ret := C.NSViewController_inst_view(
+		unsafe.Pointer(x.Pointer()),
+	)
+	r0 = NSView_fromPointer(ret)
+	return
+}
+
+func (x gen_NSViewController) SetView_(
+	value NSViewRef,
+) {
+	C.NSViewController_inst_setView_(
+		unsafe.Pointer(x.Pointer()),
+		objc.RefPointer(value),
+	)
+	return
+}
+
 func (x gen_NSViewController) Title() (
 	r0 core.NSString,
 ) {
@@ -13804,6 +13844,26 @@ func (x gen_NSViewController) PreferredMinimumSize() (
 		unsafe.Pointer(x.Pointer()),
 	)
 	r0 = *(*core.NSSize)(unsafe.Pointer(&ret))
+	return
+}
+
+func (x gen_NSViewController) SourceItemView() (
+	r0 NSView,
+) {
+	ret := C.NSViewController_inst_sourceItemView(
+		unsafe.Pointer(x.Pointer()),
+	)
+	r0 = NSView_fromPointer(ret)
+	return
+}
+
+func (x gen_NSViewController) SetSourceItemView_(
+	value NSViewRef,
+) {
+	C.NSViewController_inst_setSourceItemView_(
+		unsafe.Pointer(x.Pointer()),
+		objc.RefPointer(value),
+	)
 	return
 }
 


### PR DESCRIPTION
Updates the NSViewController schema with the IBOutlet fix from
progrium/macschema#12 to parse the types correctly.
