### PR TITLE
Add basic arm64 support

### DIFF
--- a/cocoa/cocoa_objc.gen.go
+++ b/cocoa/cocoa_objc.gen.go
@@ -7011,6 +7011,10 @@ void NSView_inst_setBackgroundColor_(void *id, void* value) {
 		setBackgroundColor: value];
 }
 
+
+BOOL cocoa_objc_bool_true = YES;
+BOOL cocoa_objc_bool_false = NO;
+
 */
 import "C"
 
@@ -7023,9 +7027,9 @@ func convertObjCBoolToGo(b C.BOOL) bool {
 
 func convertToObjCBool(b bool) C.BOOL {
 	if b {
-		return 1
+		return C.cocoa_objc_bool_true
 	}
-	return 0
+	return C.cocoa_objc_bool_false
 }
 
 func NSBundle_alloc() (

--- a/core/core_objc.gen.go
+++ b/core/core_objc.gen.go
@@ -1977,6 +1977,10 @@ BOOL NSURLRequest_inst_assumesHTTP3Capable(void *id) {
 		assumesHTTP3Capable];
 }
 
+
+BOOL core_objc_bool_true = YES;
+BOOL core_objc_bool_false = NO;
+
 */
 import "C"
 
@@ -1989,9 +1993,9 @@ func convertObjCBoolToGo(b C.BOOL) bool {
 
 func convertToObjCBool(b bool) C.BOOL {
 	if b {
-		return 1
+		return C.core_objc_bool_true
 	}
-	return 0
+	return C.core_objc_bool_false
 }
 
 func CALayer_alloc() (

--- a/gen/template/package.tmpl
+++ b/gen/template/package.tmpl
@@ -59,6 +59,10 @@ bool {{.Name}}_convertObjCBool(BOOL b) {
 		];
 }
 {{end}}
+
+BOOL {{.Name}}_objc_bool_true = YES;
+BOOL {{.Name}}_objc_bool_false = NO;
+
 */
 import "C"
 
@@ -71,9 +75,9 @@ func convertObjCBoolToGo(b C.BOOL) bool {
 
 func convertToObjCBool(b bool) C.BOOL {
 	if b {
-		return 1
+		return C.{{.Name}}_objc_bool_true
 	}
-	return 0
+	return C.{{.Name}}_objc_bool_false
 }
 {{end}}
 

--- a/misc/variadic/asmregs_arm64.h
+++ b/misc/variadic/asmregs_arm64.h
@@ -1,0 +1,21 @@
+// Copyright 2022 Mikkel Krautz. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#define REGS_X0         0
+#define REGS_X1         8
+#define REGS_X2         16
+#define REGS_X3         24
+#define REGS_X4         32
+#define REGS_X5         40
+#define REGS_X6         48
+#define REGS_X7         56
+#define REGS_Q0         64
+#define REGS_Q1         80
+#define REGS_Q2         96
+#define REGS_Q3         112
+#define REGS_Q4         128
+#define REGS_Q5         144
+#define REGS_Q6         160
+#define REGS_Q7         176
+#define REGS_ADDR       192

--- a/misc/variadic/functions.go
+++ b/misc/variadic/functions.go
@@ -7,8 +7,13 @@ import "unsafe"
 #import <objc/message.h>
 void * addr_msgSend = &objc_msgSend;
 void * addr_msgSendSuper = &objc_msgSendSuper;
+#if defined(__aarch64__)
+void * addr_msgSend_stret = NULL;
+void * addr_msgSendSuper_stret = NULL;
+#else
 void * addr_msgSend_stret = &objc_msgSend_stret;
 void * addr_msgSendSuper_stret = &objc_msgSendSuper_stret;
+#endif
 */
 import "C"
 

--- a/misc/variadic/variadic_arm64.S
+++ b/misc/variadic/variadic_arm64.S
@@ -1,0 +1,70 @@
+// Copyright 2022 Mikkel Krautz. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "asmregs_arm64.h"
+
+.align 8
+.globl _VariadicCall
+_VariadicCall:
+.globl _VariadicCallFloat
+_VariadicCallFloat:
+.globl _VariadicCallDouble
+_VariadicCallDouble:
+	sub sp, sp, 16
+	stp x29, x30, [sp]
+
+	sub sp, sp, 16
+	stp x0, x0, [sp]
+
+	mov x29, sp
+
+	mov x9, x0
+
+	ldr x0, [x9, #REGS_X0]
+	ldr x1, [x9, #REGS_X1]
+	ldr x2, [x9, #REGS_X2]
+	ldr x3, [x9, #REGS_X3]
+	ldr x4, [x9, #REGS_X4]
+	ldr x5, [x9, #REGS_X5]
+	ldr x6, [x9, #REGS_X6]
+	ldr x7, [x9, #REGS_X7]
+
+	ldr q0, [x9, #REGS_Q0]
+	ldr q1, [x9, #REGS_Q1]
+	ldr q2, [x9, #REGS_Q2]
+	ldr q3, [x9, #REGS_Q3]
+	ldr q4, [x9, #REGS_Q4]
+	ldr q5, [x9, #REGS_Q5]
+	ldr q6, [x9, #REGS_Q6]
+	ldr q7, [x9, #REGS_Q7]
+
+	ldr x10, [x9, #REGS_ADDR]
+
+	blr x10
+
+	ldr x9, [sp]
+	add sp, sp, 16
+
+	str x0, [x9, #REGS_X0]
+	str x1, [x9, #REGS_X1]
+	str x2, [x9, #REGS_X2]
+	str x3, [x9, #REGS_X3]
+	str x4, [x9, #REGS_X4]
+	str x5, [x9, #REGS_X5]
+	str x6, [x9, #REGS_X6]
+	str x7, [x9, #REGS_X7]
+
+	str q0, [x9, #REGS_Q0]
+	str q1, [x9, #REGS_Q1]
+	str q2, [x9, #REGS_Q2]
+	str q3, [x9, #REGS_Q3]
+	str q4, [x9, #REGS_Q4]
+	str q5, [x9, #REGS_Q5]
+	str q6, [x9, #REGS_Q6]
+	str q7, [x9, #REGS_Q7]
+
+	ldp x29, x30, [sp]
+	add sp, sp, 16
+
+	ret

--- a/misc/variadic/variadic_arm64.go
+++ b/misc/variadic/variadic_arm64.go
@@ -1,0 +1,91 @@
+// Copyright 2022 Mikkel Krautz. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package variadic
+
+/*
+#include <stdlib.h>
+#include <dlfcn.h>
+
+void *VariadicCall(void *ctx);
+float VariadicCallFloat(void *ctx);
+double VariadicCallDouble(void *ctx);
+
+void *LookupSymAddr(char *str) {
+	return dlsym(RTLD_DEFAULT, str);
+}
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+const (
+	X0 = iota
+	X1
+	X2
+	X3
+	X4
+	X5
+	X6
+	X7
+	Q0
+	Q1
+	Q2
+	Q3
+	Q4
+	Q5
+	Q6
+	Q7
+)
+
+type uint128 struct {
+	Upper uintptr
+	Lower uintptr
+}
+
+type FunctionCall struct {
+	Words     [8]uintptr
+	Simd      [8]uint128
+	addr      unsafe.Pointer
+}
+
+// NewFunctionCall creates a new FunctionCall than can be
+// used to call the C function named by the name parameter.
+func NewFunctionCall(name string) *FunctionCall {
+	fc := new(FunctionCall)
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	fc.addr = C.LookupSymAddr(cname)
+	return fc
+}
+
+// NewFunctionCallAddr creates a new FunctionCall that can be
+// used to cll the C function at the address given by the addr
+// parameter.
+func NewFunctionCallAddr(addr unsafe.Pointer) *FunctionCall {
+	fc := new(FunctionCall)
+	fc.addr = addr
+	return fc
+}
+
+// Call calls the FunctionCall's underlying function, returning
+// its return value as an uintptr.
+func (f *FunctionCall) Call() uintptr {
+	C.VariadicCall(unsafe.Pointer(f))
+	return f.Words[0]
+}
+
+// CallFloat32 calls the FunctionCall's underlying function, returning
+// its return value as a float32.
+func (f *FunctionCall) CallFloat32() float32 {
+	return float32(C.VariadicCallFloat(unsafe.Pointer(f)))
+}
+
+// CallFloat64 calls the FunctionCall's underlying function, returning
+// its return value as float64.
+func (f *FunctionCall) CallFloat64() float64 {
+	return float64(C.VariadicCallDouble(unsafe.Pointer(f)))
+}

--- a/objc/alloc_test.go
+++ b/objc/alloc_test.go
@@ -4,7 +4,9 @@
 
 package objc
 
-import "testing"
+import (
+	"testing"
+)
 
 type GoStruct struct {
 	Object `objc:"GoStruct : NSObject"`

--- a/objc/call_arm64.S
+++ b/objc/call_arm64.S
@@ -1,0 +1,53 @@
+// Copyright (c) 2012-2022 The 'objc' Package Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+.align 8
+.globl _GoObjc_CallTargetFrameSetup
+// uintptr GoObjc_CallTargetFrameSetup()
+_GoObjc_CallTargetFrameSetup:
+	sub sp, sp, 16
+	stp x29, x30, [sp]
+
+	sub sp, sp, 16
+	stp x0, x0, [sp]
+
+	mov x29, sp
+
+	sub sp, sp, 16
+	str q7, [sp]
+	sub sp, sp, 16
+	str q6, [sp]
+	sub sp, sp, 16
+	str q5, [sp]
+	sub sp, sp, 16
+	str q4, [sp]
+	sub sp, sp, 16
+	str q3, [sp]
+	sub sp, sp, 16
+	str q2, [sp]
+	sub sp, sp, 16
+	str q1, [sp]
+	sub sp, sp, 16
+	str q0, [sp]
+	sub sp, sp, 16
+	stp x6, x7, [sp]
+	sub sp, sp, 16
+	stp x4, x5, [sp]
+	sub sp, sp, 16
+	stp x2, x3, [sp]
+	sub sp, sp, 16
+	stp x0, x1, [sp]
+
+	mov x0, sp
+
+	bl _goMethodCallEntryPoint
+
+	add sp, sp, 192 // Restore stack
+
+	add sp, sp, 16 // Restore x0
+
+	ldp x29, x30, [sp]
+	add sp, sp, 16
+
+	ret

--- a/objc/call_arm64.go
+++ b/objc/call_arm64.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2012-2022 The 'objc' Package Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package objc
+
+/*
+extern unsigned long GoObjc_CallTargetFrameSetup;
+*/
+import "C"
+import (
+	"math"
+	"reflect"
+	"unsafe"
+)
+
+type uint128 struct {
+	Upper uintptr
+	Lower uintptr
+}
+
+// arm64frame represents the layout of the
+// register set once it's pushed onto the stack
+// when the Objective-C runtime calls our call target.
+type arm64frame struct {
+	x0 uintptr
+	x1 uintptr
+	x2 uintptr
+	x3 uintptr
+	x4 uintptr
+	x5 uintptr
+	x6 uintptr
+	x7 uintptr
+	q0 uint128
+	q1 uint128
+	q2 uint128
+	q3 uint128
+	q4 uint128
+	q5 uint128
+	q6 uint128
+	q7 uint128
+}
+
+// arm64frameFetcher implements the logic needed
+// to fetch arguments from an arm64frame in the
+// correct order.
+type arm64frameFetcher struct {
+	frame  *arm64frame
+	ints   *[8]uintptr
+	floats *[8]uint128
+	ioff   int
+	foff   int
+	soff   int
+}
+
+// frameFetcher returns a new arm64frameFetcher that
+// wraps an existing arm64 frame.
+func frameFetcher(frame *arm64frame) arm64frameFetcher {
+	ints := (*[8]uintptr)(unsafe.Pointer(frame))
+	floats := (*[8]uint128)(unsafe.Pointer(&frame.q0))
+	return arm64frameFetcher{
+		ints:   ints,
+		floats: floats,
+	}
+}
+
+// Int returns the next integer argument from the arm64frame
+// wrapped by the frame fetcher.
+func (ff *arm64frameFetcher) Int() uintptr {
+	if ff.ioff < len(ff.ints) {
+		val := ff.ints[ff.ioff]
+		ff.ioff++
+		return val
+	}
+	return ff.Stack()
+}
+
+// Float returns the next floating point argument from the arm64
+// frame wrapped by the frame fetcher.
+func (ff *arm64frameFetcher) Float() uintptr {
+	if ff.foff < len(ff.floats) {
+		val := ff.floats[ff.foff].Upper
+		ff.foff++
+		return val
+	}
+	return ff.Stack()
+}
+
+// Stack returns the next stack argument from arm64
+// frame wrapped by the frame fetcher.
+func (ff *arm64frameFetcher) Stack() uintptr {
+	panic("arm64frameFetcher: stack fetching not supported")
+}
+
+// methodCallTarget returns a pointer to the entry point
+// that the Objective-C runtime must call to reach an
+// exported method from Go.
+func methodCallTarget() unsafe.Pointer {
+	return unsafe.Pointer(&C.GoObjc_CallTargetFrameSetup)
+}
+
+// setIBOutletValue attempts to assign the Objective-C object represented
+// by 'value' to the field named 'name' in the Go struct represented by 'obj'.
+//
+// The function sends the 'retain' message to the Objective-C object represented
+// by 'value' if the assignment was successful.
+//
+// If the assignment operation fails, this function will raise a runtime panic.
+func setIBOutletValue(obj reflect.Value, name string, value Object) {
+	// Find an IBOutlet with the name keyName.
+	val := obj.Elem()
+	typ := val.Type()
+	fieldIdx := -1
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Tag.Get("objc") == "IBOutlet" && field.Type.Implements(objectInterfaceType) {
+			if field.Name == name {
+				fieldIdx = i
+				break
+			}
+		}
+	}
+
+	// If we couldn't find a matching field, simply panic.
+	// We should only run into this is there is a bug in the package.
+	if fieldIdx == -1 {
+		panic("objc: bad setter for IBOutlet field '" + name + "'")
+	}
+
+	fieldVal := val.Field(fieldIdx)
+	fieldVal.Set(reflect.ValueOf(value))
+	value.Retain()
+}
+
+//export goMethodCallEntryPoint
+func goMethodCallEntryPoint(p uintptr) uintptr {
+	frame := (*arm64frame)(unsafe.Pointer(p))
+	fetcher := frameFetcher(frame)
+
+	obj := object{ptr: fetcher.Int()}
+	sel := stringFromSelector(unsafe.Pointer(fetcher.Int()))
+
+	clsName := object{ptr: getObjectClass(obj).Pointer()}.className()
+	clsInfo := classMap[clsName]
+	method := clsInfo.MethodForSelector(sel)
+
+	// Check if we have an internal pointer set for this object.
+	// If not, make it happen.
+	internalPtr := obj.internalPointer()
+	if internalPtr == nil {
+		// Allocate the Go struct.
+		val := reflect.New(clsInfo.typ)
+		ptr := unsafe.Pointer(val.Pointer())
+		// Add a reference in the classInfo. This ensures we have
+		// a reference to our Go struct somewhere in Go land, which
+		// makes the garbage collector not collect it under our feet.
+		clsInfo.AddRef(ptr)
+		// Set the internalPointer so we can easily access
+		// the instance's Go struct pointer.
+		obj.setInternalPointer(ptr)
+		internalPtr = ptr
+		// Finally, update the Go struct's embedded objc.Object to
+		// point to the actual Objective-C instance.
+		structVal := val.Elem()
+		if structVal.Kind() == reflect.Struct {
+			objectVal := structVal.FieldByName("Object")
+			if objectVal.IsValid() {
+				objectVal.Set(reflect.ValueOf(obj))
+			}
+		}
+	}
+	objVal := reflect.NewAt(clsInfo.typ, internalPtr)
+
+	// Check if the invoked selector is a setter for IBOutlets.
+	if _, isSetter := clsInfo.setters[sel]; isSetter {
+		valuePtr := fetcher.Int()
+		keyName := sel[3:]                    // strip 'set'
+		keyName = keyName[0 : len(keyName)-1] // strip ':'
+		setIBOutletValue(objVal, keyName, object{ptr: valuePtr})
+		return 0
+	}
+
+	// Our own internal override for setValue:forKey: in order
+	// to support key-value coding. (For IBOutlets on iOS)
+	if sel == "setValue:forKey:" && method == nil {
+		// We only support Object values, so fetching
+		// Ints here is OK.
+		valuePtr := fetcher.Int()
+		keyPtr := fetcher.Int()
+
+		// We don't export any NSString-based functionality
+		// in package objc, except for the String() method
+		// on object.  It calls the object's decription method,
+		// which for NSStrings returns the string itself (or at
+		// least something that has been good enough for now!).
+		keyName := object{ptr: keyPtr}.String()
+
+		setIBOutletValue(objVal, keyName, object{ptr: valuePtr})
+		return 0
+	}
+
+	// The default dealloc implementation. This is called
+	// if a class doesn't register its own custom dealloc
+	// method.
+	if sel == "dealloc" && method == nil {
+		clsInfo.RemoveRef(internalPtr)
+		obj.SendSuper("dealloc")
+		return 0
+	}
+
+	methodVal := reflect.ValueOf(method)
+
+	// First argument should point to the Go method's proper receiver.
+	// That's stored in the internalPointer, so fetch that.
+	args := []reflect.Value{objVal}
+
+	// Take care of the rest of the arguments
+	mt := reflect.TypeOf(method)
+	for i := 1; i < mt.NumIn(); i++ {
+		typ := mt.In(i)
+
+		if typ.Implements(objectInterfaceType) {
+			args = append(args, reflect.ValueOf(object{ptr: fetcher.Int()}))
+			continue
+		} else if typ.Implements(selectorInterfaceType) {
+			sel := selector(stringFromSelector(unsafe.Pointer(fetcher.Int())))
+			args = append(args, reflect.ValueOf(sel))
+			continue
+		}
+
+		switch typ.Kind() {
+		case reflect.Int:
+			args = append(args, reflect.ValueOf(int(fetcher.Int())))
+		case reflect.Int8:
+			args = append(args, reflect.ValueOf(int8(fetcher.Int())))
+		case reflect.Int16:
+			args = append(args, reflect.ValueOf(int16(fetcher.Int())))
+		case reflect.Int32:
+			args = append(args, reflect.ValueOf(int32(fetcher.Int())))
+		case reflect.Int64:
+			args = append(args, reflect.ValueOf(int64(fetcher.Int())))
+
+		case reflect.Uint8:
+			args = append(args, reflect.ValueOf(uint8(fetcher.Int())))
+		case reflect.Uint16:
+			args = append(args, reflect.ValueOf(uint16(fetcher.Int())))
+		case reflect.Uint32:
+			args = append(args, reflect.ValueOf(uint32(fetcher.Int())))
+		case reflect.Uint64:
+			args = append(args, reflect.ValueOf(uint64(fetcher.Int())))
+		case reflect.Uintptr:
+			args = append(args, reflect.ValueOf(fetcher.Int()))
+
+		case reflect.Float32:
+			args = append(args, reflect.ValueOf(math.Float32frombits(uint32(fetcher.Float()))))
+		case reflect.Float64:
+			args = append(args, reflect.ValueOf(math.Float64frombits(uint64(fetcher.Float()))))
+
+		case reflect.Bool:
+			val := fetcher.Int() != 0
+			args = append(args, reflect.ValueOf(val))
+
+		case reflect.Ptr:
+			ptrAddr := unsafe.Pointer(uintptr(fetcher.Int()))
+			args = append(args, reflect.NewAt(typ.Elem(), ptrAddr))
+
+		default:
+			panic("call: unhandled arg")
+		}
+	}
+
+	retVals := methodVal.Call(args)
+
+	// If a custom dealloc method has been registered, we
+	// still need to remove the reference to our Go struct
+	// pointer in order for the GC to kick in. Do that now.
+	if sel == "dealloc" {
+		clsInfo.RemoveRef(internalPtr)
+	}
+
+	if len(retVals) > 0 {
+		val := retVals[0]
+		switch val.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return uintptr(val.Int())
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			return uintptr(val.Uint())
+		case reflect.Bool:
+			if val.Bool() {
+				return 1
+			} else {
+				return 0
+			}
+		case reflect.Float32:
+			frame.q0.Upper = uintptr(math.Float32bits(float32(val.Float())))
+			return 1
+		case reflect.Float64:
+			frame.q0.Upper = uintptr(math.Float64bits(val.Float()))
+			return 1
+		case reflect.Interface:
+			if obj, ok := val.Interface().(Object); ok {
+				return obj.Pointer()
+			}
+			panic("call: bad interface return value")
+		default:
+			panic("call: unknown return value")
+		}
+	}
+
+	return 0
+}

--- a/objc/msg_arm64.go
+++ b/objc/msg_arm64.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2012-2022 The 'objc' Package Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package objc
+
+/*
+//#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -lobjc -framework Foundation
+#define OBJC_OLD_DISPATCH_PROTOTYPES 1
+
+// #cgo LDFLAGS: -lobjc -framework Foundation
+#define __OBJC2__ 1
+#include <objc/runtime.h>
+#include <objc/message.h>
+#include <stdlib.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+void *GoObjc_GetObjectSuperClassStruct(void *obj) {
+	struct objc_super *s = malloc(sizeof(struct objc_super));
+	s->receiver = obj;
+	s->super_class = class_getSuperclass(object_getClass(obj));
+	return s;
+}
+*/
+import "C"
+import (
+	"log"
+	"math"
+	"reflect"
+	"unsafe"
+
+	"github.com/progrium/macdriver/misc/variadic"
+)
+
+func unpackStruct(val reflect.Value, intArgs []uintptr, floatArgs []uintptr) (updatedIntArgs []uintptr, updatedFloatArgs []uintptr) {
+	for i := 0; i < val.NumField(); i++ {
+		v := val.Field(i)
+		kind := v.Kind()
+		switch kind {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			intArgs = append(intArgs, uintptr(v.Int()))
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			intArgs = append(intArgs, uintptr(v.Uint()))
+		case reflect.Float32, reflect.Float64:
+			floatArgs = append(floatArgs, uintptr(math.Float64bits(v.Float())))
+		case reflect.Ptr:
+			intArgs = append(intArgs, val.Pointer())
+		case reflect.Struct:
+			ia, fa := unpackStruct(v, intArgs, floatArgs)
+			intArgs = ia
+			floatArgs = fa
+		default:
+			panic("unhandled case")
+		}
+	}
+	return intArgs, floatArgs
+}
+
+func sendMsg(obj Object, sendFunc variadic.Function, selector string, args ...interface{}) Object {
+	// Keep ObjC semantics: messages can be sent to nil objects,
+	// but the response is nil.
+	if obj.Pointer() == 0 {
+		return obj
+	}
+
+	sel := selectorWithName(selector)
+	if sel == nil {
+		return nil
+	}
+
+	intArgs := []uintptr{}
+	floatArgs := []uintptr{}
+	argOffset := 2 // self, op
+
+	typeInfo := simpleTypeInfoForMethod(obj, sel)
+
+	for i, arg := range args {
+		if args[i] == nil {
+			intArgs = append(intArgs, uintptr(0))
+			continue
+		}
+		switch t := arg.(type) {
+		case Object:
+			intArgs = append(intArgs, t.Pointer())
+		case Selector:
+			intArgs = append(intArgs, uintptr(selectorWithName(t.Selector())))
+		case uintptr:
+			intArgs = append(intArgs, t)
+		case int:
+			intArgs = append(intArgs, uintptr(t))
+		case uint:
+			intArgs = append(intArgs, uintptr(t))
+		case int8:
+			intArgs = append(intArgs, uintptr(t))
+		case uint8:
+			intArgs = append(intArgs, uintptr(t))
+		case int16:
+			intArgs = append(intArgs, uintptr(t))
+		case uint16:
+			intArgs = append(intArgs, uintptr(t))
+		case int32:
+			intArgs = append(intArgs, uintptr(t))
+		case uint32:
+			intArgs = append(intArgs, uintptr(t))
+		case int64:
+			intArgs = append(intArgs, uintptr(t))
+		case uint64:
+			intArgs = append(intArgs, uintptr(t))
+		case bool:
+			if t {
+				intArgs = append(intArgs, uintptr(1))
+			} else {
+				intArgs = append(intArgs, uintptr(0))
+			}
+		case float32:
+			floatArgs = append(floatArgs, uintptr(math.Float32bits(t)))
+		// Float64 is a bit of a special case. Since SendMsg is a variadic
+		// Go function, implicit floats will be of type float64, but we can't
+		// be sure that the receiver expects that; they might expect a float32
+		// instead.
+		//
+		// To remedy this, we query the selector's type encoding, and check
+		// whether it expects a 32-bit or 64-bit float.
+		case float64:
+			typeEnc := string(typeInfo[i+3])
+			switch typeEnc {
+			case encFloat:
+				floatArgs = append(floatArgs, uintptr(math.Float32bits(float32(t))))
+			case encDouble:
+				floatArgs = append(floatArgs, uintptr(math.Float64bits(t)))
+			default:
+				panic("objc: float argument mismatch")
+			}
+		default:
+			val := reflect.ValueOf(args[i])
+			switch val.Kind() {
+			case reflect.Ptr:
+				intArgs = append(intArgs, val.Pointer())
+			case reflect.Uintptr:
+				intArgs = append(intArgs, uintptr(val.Uint()))
+			case reflect.Struct:
+				updatedIntArgs, updatedFloatArgs := unpackStruct(val, intArgs, floatArgs)
+				intArgs = updatedIntArgs
+				floatArgs = updatedFloatArgs
+				// B.4	If the argument type is a Composite Type that is larger than
+				// 16 bytes, then the argument is copied to memory allocated by the
+				// caller and the argument is replaced by a pointer to the copy.
+				//if len(args) > 2 {
+				//	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&args))
+				//	intArgs = append(intArgs, uintptr(hdr.Data))
+				//} else {
+				//	intArgs = append(intArgs, args...)
+				//}
+			case reflect.Uint, reflect.Int, reflect.Int64, reflect.Uint64:
+				intArgs = append(intArgs, uintptr(val.Uint()))
+			default:
+				log.Panicf("unhandled kind: %s", val.Kind())
+			}
+		}
+	}
+
+	// only objc_msgSend_stret supported for now,
+	// with limited arg counts and type support
+	/*if sendFunc.IsStRet() {
+		switch len(intArgs) {
+		case 0:
+			C.GoObjc_MsgSend_Stret0(unsafe.Pointer(stretAddr), unsafe.Pointer(obj.Pointer()), sel)
+			return object{ptr: 0}
+		case 1:
+			C.GoObjc_MsgSend_Stret1(unsafe.Pointer(stretAddr), unsafe.Pointer(obj.Pointer()), sel, unsafe.Pointer(intArgs[0]))
+			return object{ptr: 0}
+		default:
+			log.Panicf("unsupported arg count for data-structure return call: %v(%d)", sendFunc, len(intArgs))
+		}
+	}*/
+
+	fc := sendFunc.NewCall()
+	if sendFunc.IsSuper() {
+		superPtr := C.GoObjc_GetObjectSuperClassStruct(unsafe.Pointer(obj.Pointer()))
+		defer C.free(superPtr)
+		fc.Words[0] = uintptr(superPtr)
+	} else {
+		fc.Words[0] = obj.Pointer()
+	}
+	fc.Words[1] = uintptr(sel)
+
+	if len(intArgs) > 8 {
+		panic("too many int args")
+	}
+	if len(floatArgs) > 8 {
+		panic("too many float args")
+	}
+
+	for i, v := range intArgs {
+		fc.Words[argOffset+i] = v
+	}
+
+	for i, v := range floatArgs {
+		fc.Simd[i].Upper = v
+	}
+
+	if len(typeInfo) > 0 {
+		retEnc := string(typeInfo[0])
+		if retEnc == encFloat {
+			return object{ptr: uintptr(math.Float32bits(fc.CallFloat32()))}
+		} else if retEnc == encDouble {
+			return object{ptr: uintptr(math.Float64bits(fc.CallFloat64()))}
+		}
+	}
+
+	return object{ptr: fc.Call()}
+}
+
+func (obj object) Send(selector string, args ...interface{}) Object {
+	return sendMsg(obj, variadic.F_msgSend, selector, args...)
+}
+
+// func (obj object) SendMsgStret(ret uintptr, selector string, args ...interface{}) {
+// 	sel := selectorWithName(selector)
+// 	C.Debug_MsgSend_Stret(unsafe.Pointer(ret), unsafe.Pointer(obj.Pointer()), sel)
+// }
+
+func (obj object) SendSuper(selector string, args ...interface{}) Object {
+	return sendMsg(obj, variadic.F_msgSendSuper, selector, args...)
+}

--- a/objc/msg_arm64.go
+++ b/objc/msg_arm64.go
@@ -161,20 +161,9 @@ func sendMsg(obj Object, sendFunc variadic.Function, selector string, args ...in
 		}
 	}
 
-	// only objc_msgSend_stret supported for now,
-	// with limited arg counts and type support
-	/*if sendFunc.IsStRet() {
-		switch len(intArgs) {
-		case 0:
-			C.GoObjc_MsgSend_Stret0(unsafe.Pointer(stretAddr), unsafe.Pointer(obj.Pointer()), sel)
-			return object{ptr: 0}
-		case 1:
-			C.GoObjc_MsgSend_Stret1(unsafe.Pointer(stretAddr), unsafe.Pointer(obj.Pointer()), sel, unsafe.Pointer(intArgs[0]))
-			return object{ptr: 0}
-		default:
-			log.Panicf("unsupported arg count for data-structure return call: %v(%d)", sendFunc, len(intArgs))
-		}
-	}*/
+	if sendFunc.IsStRet() {
+		panic("objc: stret is not yet supported on arm64")
+	}
 
 	fc := sendFunc.NewCall()
 	if sendFunc.IsSuper() {

--- a/objc/object_arm64.go
+++ b/objc/object_arm64.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2013 The 'objc' Package Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package objc
+
+import "math"
+
+func (obj object) Uint() uint64 {
+	return uint64(obj.ptr)
+}
+
+func (obj object) Int() int64 {
+	return int64(obj.ptr)
+}
+
+func (obj object) Bool() bool {
+	return obj.ptr == 1
+}
+
+func (obj object) Float() float64 {
+	// fixme(mkrautz): 64-bit only only; also not sure if
+	// this check is even valid for IEEE floats.
+	if obj.ptr&0xffffffff00000000 == 0 {
+		return float64(math.Float32frombits(uint32(obj.ptr)))
+	}
+	return math.Float64frombits(uint64(obj.ptr))
+}

--- a/objc/typeinfo_arm64.go
+++ b/objc/typeinfo_arm64.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2012-2022 The 'objc' Package Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package objc
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func typeInfoForType(typ reflect.Type) string {
+	if typ.Implements(classInterfaceType) {
+		return encClass
+	} else if typ.Implements(objectInterfaceType) {
+		return encId
+	} else if typ.Implements(selectorInterfaceType) {
+		return encSelector
+	}
+
+	kind := typ.Kind()
+	switch kind {
+	case reflect.Bool:
+		return encBool
+	case reflect.Int:
+		return encInt
+	case reflect.Int8:
+		return encChar
+	case reflect.Int16:
+		return encShort
+	case reflect.Int32:
+		return encInt
+	case reflect.Int64:
+		return encULong
+	case reflect.Uint:
+		return encUInt
+	case reflect.Uint8:
+		return encUChar
+	case reflect.Uint16:
+		return encUShort
+	case reflect.Uint32:
+		return encUInt
+	case reflect.Uint64:
+		return encULong
+	case reflect.Uintptr:
+		return encPtr
+	case reflect.Float32:
+		return encFloat
+	case reflect.Float64:
+		return encDouble
+	case reflect.Ptr:
+		return encPtr
+	}
+
+	panic("typeinfo: unhandled/invalid kind " + fmt.Sprintf("%v", kind) + " " + fmt.Sprintf("%v", typ))
+}

--- a/webkit/webkit_objc.gen.go
+++ b/webkit/webkit_objc.gen.go
@@ -458,6 +458,10 @@ void WKPreferences_inst_setTextInteractionEnabled_(void *id, BOOL value) {
 		setTextInteractionEnabled: value];
 }
 
+
+BOOL webkit_objc_bool_true = YES;
+BOOL webkit_objc_bool_false = NO;
+
 */
 import "C"
 
@@ -470,9 +474,9 @@ func convertObjCBoolToGo(b C.BOOL) bool {
 
 func convertToObjCBool(b bool) C.BOOL {
 	if b {
-		return 1
+		return C.webkit_objc_bool_true
 	}
-	return 0
+	return C.webkit_objc_bool_false
 }
 
 func WKNavigation_alloc() (


### PR DESCRIPTION
This pull request implements basic arm64 support.

Tested with topframe and pomodoro examples, as well as all existing tests in objc and variadic.

I am not sure how much the new gan-infrastructure still relies on objc and misc/variadic? If there is something else that would make better sense to test, let me know.

Notes:
This is pretty basic support. It doesn't yet support overflowing parameters to the stack - so it relies on there being enough registers to pass all expected parameters. This is true both for the variadic and the "call" module of the objc package, which is used to implement ObjC objects in Go.
I've not yet run into issues, but I thought this was a good starting point. Since this is something that pops up at development-time, that should raise a flag for when/if further development to support overflowing to the stack is needed.

It also doesn't support struct returns (stret) yet.
