### PR TITLE
gen: Remove `_As*` pattern to clean up generated code

### DIFF
--- a/cocoa/NSApplication.go
+++ b/cocoa/NSApplication.go
@@ -24,7 +24,7 @@ func init() {
 		return TerminateAfterWindowsClose
 	})
 	objc.RegisterClass(DefaultDelegateClass)
-	DefaultDelegate = objc.Get("DefaultDelegate").Alloc().Init()
+	DefaultDelegate = objc.Get("DefaultDelegate").Alloc().InitObject()
 }
 
 type NSApplication struct {
@@ -32,7 +32,7 @@ type NSApplication struct {
 }
 
 func NSApplication_New() NSApplication {
-	return NSApplication_Alloc().Init_AsNSApplication()
+	return NSApplication_Alloc().Init()
 }
 
 func NSApp() NSApplication {

--- a/cocoa/NSControl.go
+++ b/cocoa/NSControl.go
@@ -9,5 +9,5 @@ type NSControl struct {
 }
 
 func NSControl_Init(frame core.NSRect) NSControl {
-	return NSControl_Alloc().InitWithFrame_AsNSControl(frame)
+	return NSControl_Alloc().InitWithFrame(frame)
 }

--- a/cocoa/NSImage.go
+++ b/cocoa/NSImage.go
@@ -9,11 +9,11 @@ type NSImage struct {
 }
 
 func NSImage_InitWithData(data core.NSDataRef) NSImage {
-	return NSImage_Alloc().InitWithData_AsNSImage(data)
+	return NSImage_Alloc().InitWithData(data)
 }
 
 func NSImage_InitWithURL(url core.NSURL) NSImage {
-	return NSImage_Alloc().InitWithContentsOfURL_AsNSImage(url)
+	return NSImage_Alloc().InitWithContentsOfURL(url)
 }
 
 func NSImage_ImageNamed(name string) NSImage {

--- a/cocoa/NSImageView.go
+++ b/cocoa/NSImageView.go
@@ -5,5 +5,5 @@ type NSImageView struct {
 }
 
 func NSImageView_New() NSImageView {
-	return NSImageView_Alloc().Init_AsNSImageView()
+	return NSImageView_Alloc().Init()
 }

--- a/cocoa/NSImage_test.go
+++ b/cocoa/NSImage_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNSImageSize(t *testing.T) {
-	img := NSImage_Alloc().InitWithSize_AsNSImage(core.Size(100, 200))
+	img := NSImage_Alloc().InitWithSize(core.Size(100, 200))
 	size := img.Size()
 	assert.EqualValues(t, 100, size.Width)
 	assert.EqualValues(t, 200, size.Height)

--- a/cocoa/NSMenu.go
+++ b/cocoa/NSMenu.go
@@ -9,7 +9,7 @@ type NSMenu struct {
 }
 
 func NSMenu_New() NSMenu {
-	return NSMenu_Alloc().Init_AsNSMenu()
+	return NSMenu_Alloc().Init()
 }
 
 func NSMenu_Init(title string) NSMenu {

--- a/cocoa/NSMenu.go
+++ b/cocoa/NSMenu.go
@@ -13,7 +13,7 @@ func NSMenu_New() NSMenu {
 }
 
 func NSMenu_Init(title string) NSMenu {
-	return NSMenu_Alloc().InitWithTitle_AsNSMenu(core.String(title))
+	return NSMenu_Alloc().InitWithTitle(core.String(title))
 }
 
 func (menu NSMenu) Title() string {

--- a/cocoa/NSMenuItem.go
+++ b/cocoa/NSMenuItem.go
@@ -20,7 +20,7 @@ func NSMenuItem_Init(itemName string, action objc.Selector, keyEquivalent string
 
 // NSMenuItem_New returns an initialized instance of NSMenuItem.
 func NSMenuItem_New() NSMenuItem {
-	return NSMenuItem_Alloc().Init_AsNSMenuItem()
+	return NSMenuItem_Alloc().Init()
 }
 
 // NSMenuItem_Separator returns a menu item that is used to separate logical groups of menu commands.

--- a/cocoa/NSMenuItem.go
+++ b/cocoa/NSMenuItem.go
@@ -14,7 +14,7 @@ type NSMenuItem struct {
 // NSMenuItem_Init returns an initialized instance of NSMenuItem.
 // https://developer.apple.com/documentation/appkit/nsmenuitem/1514858-initwithtitle?language=objc
 func NSMenuItem_Init(itemName string, action objc.Selector, keyEquivalent string) NSMenuItem {
-	return NSMenuItem_Alloc().InitWithTitleActionKeyEquivalent_AsNSMenuItem(
+	return NSMenuItem_Alloc().InitWithTitleActionKeyEquivalent(
 		core.String(itemName), action, core.String(keyEquivalent))
 }
 

--- a/cocoa/NSNib.go
+++ b/cocoa/NSNib.go
@@ -16,7 +16,7 @@ func NSNib_InitWithNibNamed_Bundle(name string, bundle NSBundle) NSNib {
 }
 
 func NSNib_InitWithNibData_Bundle(data core.NSDataRef, bundle NSBundleRef) NSNib {
-	return NSNib_Alloc().InitWithNibDataBundle_AsNSNib(data, bundle)
+	return NSNib_Alloc().InitWithNibDataBundle(data, bundle)
 }
 
 func (nib NSNib) InstantiateWithOwner_TopLevelObjects(owner objc.Object) (core.NSArray, bool) {

--- a/cocoa/NSPopover.go
+++ b/cocoa/NSPopover.go
@@ -14,7 +14,7 @@ const (
 )
 
 func NSPopover_Init() NSPopover {
-	return NSPopover_Alloc().Init_AsNSPopover()
+	return NSPopover_Alloc().Init()
 }
 
 func (p NSPopover) SetContentSize(s core.NSSize) {

--- a/cocoa/NSSound.go
+++ b/cocoa/NSSound.go
@@ -9,17 +9,5 @@ type NSSound struct {
 }
 
 func NSSound_InitWithData(data core.NSDataRef) NSSound {
-	return NSSound_Alloc().InitWithData_AsNSSound(data)
-}
-
-func (sound NSSound) Play() {
-	sound.Play()
-}
-
-func (sound NSSound) Pause() {
-	sound.Pause()
-}
-
-func (sound NSSound) Resume() {
-	sound.Resume()
+	return NSSound_Alloc().InitWithData(data)
 }

--- a/cocoa/NSTextView.go
+++ b/cocoa/NSTextView.go
@@ -19,7 +19,7 @@ type NSTextView struct {
 }
 
 func NSTextView_Init(frame core.NSRect) NSTextView {
-	return NSTextView_Alloc().InitWithFrame_AsNSTextView(frame)
+	return NSTextView_Alloc().InitWithFrame(frame)
 }
 
 func (v NSTextView) String() string {

--- a/cocoa/NSView.go
+++ b/cocoa/NSView.go
@@ -10,7 +10,7 @@ type NSView struct {
 }
 
 func NSView_Init(frame core.NSRect) NSView {
-	return NSView_Alloc().InitWithFrame_AsNSView(frame)
+	return NSView_Alloc().InitWithFrame(frame)
 }
 
 func (v NSView) AddSubviewPositionedRelativeTo(subview NSViewRef, positioned int, relativeTo NSViewRef) {

--- a/cocoa/NSViewController.go
+++ b/cocoa/NSViewController.go
@@ -3,7 +3,7 @@ package cocoa
 type NSViewController struct{ gen_NSViewController }
 
 func NSViewController_New() NSViewController {
-	return NSViewController_Alloc().Init_AsNSViewController()
+	return NSViewController_Alloc().Init()
 }
 
 func (c NSViewController) SetView(v NSView) {

--- a/cocoa/NSVisualEffectView.go
+++ b/cocoa/NSVisualEffectView.go
@@ -10,7 +10,7 @@ type NSVisualEffectView struct {
 }
 
 func NSVisualEffectView_New() NSVisualEffectView {
-	return NSVisualEffectView_Alloc().Init_AsNSVisualEffectView()
+	return NSVisualEffectView_Alloc().Init()
 }
 
 // effect.Set("translatesAutoresizingMaskIntoConstraints:", false)

--- a/cocoa/NSWindow.go
+++ b/cocoa/NSWindow.go
@@ -20,7 +20,7 @@ func NSWindow_WithContentViewController(controller NSViewControllerRef) NSWindow
 }
 
 func NSWindow_Init(rect core.NSRect, windowStyle core.NSUInteger, bufferingType NSBackingStoreType, deferCreation bool) NSWindow {
-	return NSWindow_Alloc().InitWithContentRectStyleMaskBackingDefer_AsNSWindow(
+	return NSWindow_Alloc().InitWithContentRectStyleMaskBackingDefer(
 		rect, core.NSUInteger(windowStyle), core.NSUInteger(bufferingType), deferCreation,
 	)
 }

--- a/cocoa/NSWindow.go
+++ b/cocoa/NSWindow.go
@@ -12,7 +12,7 @@ type NSWindow struct {
 var nsWindow = objc.Get("NSWindow")
 
 func NSWindow_New() NSWindow {
-	return NSWindow_Alloc().Init_AsNSWindow()
+	return NSWindow_Alloc().Init()
 }
 
 func NSWindow_WithContentViewController(controller NSViewControllerRef) NSWindow {
@@ -63,10 +63,6 @@ func (w NSWindow) Opaque() bool {
 
 func (w NSWindow) MovableByWindowBackground() bool {
 	return w.IsMovableByWindowBackground()
-}
-
-func (w NSWindow) SetFrameDisplay(frame core.NSRect, display bool) {
-	w.SetFrameDisplay(frame, display)
 }
 
 func (w NSWindow) CollectionBehavior() uint {

--- a/cocoa/cocoa_objc.gen.go
+++ b/cocoa/cocoa_objc.gen.go
@@ -9100,7 +9100,7 @@ func (x gen_NSBundle) Unload() bool {
 }
 
 // Init is undocumented.
-func (x gen_NSBundle) Init_AsNSBundle() NSBundle {
+func (x gen_NSBundle) Init() NSBundle {
 	ret := C.NSBundle_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -9499,7 +9499,7 @@ func (x gen_NSSound) WriteToPasteboard(
 }
 
 // Init is undocumented.
-func (x gen_NSSound) Init_AsNSSound() NSSound {
+func (x gen_NSSound) Init() NSSound {
 	ret := C.NSSound_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -9954,7 +9954,7 @@ func (x gen_NSApplication) UnregisterUserInterfaceItemSearchHandler(
 }
 
 // Init is undocumented.
-func (x gen_NSApplication) Init_AsNSApplication() NSApplication {
+func (x gen_NSApplication) Init() NSApplication {
 	ret := C.NSApplication_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -10470,7 +10470,7 @@ func (x gen_NSControl) ValidateEditing() {
 }
 
 // Init is undocumented.
-func (x gen_NSControl) Init_AsNSControl() NSControl {
+func (x gen_NSControl) Init() NSControl {
 	ret := C.NSControl_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -10965,7 +10965,7 @@ func (x gen_NSButton) SetNextState() {
 }
 
 // Init is undocumented.
-func (x gen_NSButton) Init_AsNSButton() NSButton {
+func (x gen_NSButton) Init() NSButton {
 	ret := C.NSButton_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -11468,7 +11468,7 @@ func NSEvent_FromRef(ref objc.Ref) NSEvent {
 }
 
 // Init is undocumented.
-func (x gen_NSEvent) Init_AsNSEvent() NSEvent {
+func (x gen_NSEvent) Init() NSEvent {
 	ret := C.NSEvent_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -11939,7 +11939,7 @@ func (x gen_NSFont) Set() {
 }
 
 // Init is undocumented.
-func (x gen_NSFont) Init_AsNSFont() NSFont {
+func (x gen_NSFont) Init() NSFont {
 	ret := C.NSFont_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12303,7 +12303,7 @@ func (x gen_NSImage) UnlockFocus() {
 }
 
 // Init is undocumented.
-func (x gen_NSImage) Init_AsNSImage() NSImage {
+func (x gen_NSImage) Init() NSImage {
 	ret := C.NSImage_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12603,7 +12603,7 @@ func NSImageView_FromRef(ref objc.Ref) NSImageView {
 }
 
 // Init is undocumented.
-func (x gen_NSImageView) Init_AsNSImageView() NSImageView {
+func (x gen_NSImageView) Init() NSImageView {
 	ret := C.NSImageView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12788,7 +12788,7 @@ func (x gen_NSNib) InstantiateWithOwnerTopLevelObjects(
 }
 
 // Init is undocumented.
-func (x gen_NSNib) Init_AsNSNib() NSNib {
+func (x gen_NSNib) Init() NSNib {
 	ret := C.NSNib_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12944,7 +12944,7 @@ func (x gen_NSPasteboard) WriteObjects(
 }
 
 // Init is undocumented.
-func (x gen_NSPasteboard) Init_AsNSPasteboard() NSPasteboard {
+func (x gen_NSPasteboard) Init() NSPasteboard {
 	ret := C.NSPasteboard_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -13157,7 +13157,7 @@ func (x gen_NSLayoutManager) GlyphIndexForCharacterAtIndex(
 // Init initializes a newly created layout manager object.
 //
 // See https://developer.apple.com/documentation/uikit/nslayoutmanager/1402975-init?language=objc for details.
-func (x gen_NSLayoutManager) Init_AsNSLayoutManager() NSLayoutManager {
+func (x gen_NSLayoutManager) Init() NSLayoutManager {
 	ret := C.NSLayoutManager_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -14009,7 +14009,7 @@ func (x gen_NSMenu) Update() {
 }
 
 // Init is undocumented.
-func (x gen_NSMenu) Init_AsNSMenu() NSMenu {
+func (x gen_NSMenu) Init() NSMenu {
 	ret := C.NSMenu_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -14319,7 +14319,7 @@ func (x gen_NSPopover) Close() {
 // Init is undocumented.
 //
 // See https://developer.apple.com/documentation/appkit/nspopover/1526851-init?language=objc for details.
-func (x gen_NSPopover) Init_AsNSPopover() NSPopover {
+func (x gen_NSPopover) Init() NSPopover {
 	ret := C.NSPopover_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -14501,7 +14501,7 @@ func (x gen_NSMenuItem) InitWithTitleActionKeyEquivalent(
 }
 
 // Init is undocumented.
-func (x gen_NSMenuItem) Init_AsNSMenuItem() NSMenuItem {
+func (x gen_NSMenuItem) Init() NSMenuItem {
 	ret := C.NSMenuItem_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15214,7 +15214,7 @@ func (x gen_NSRunningApplication) Unhide() bool {
 }
 
 // Init is undocumented.
-func (x gen_NSRunningApplication) Init_AsNSRunningApplication() NSRunningApplication {
+func (x gen_NSRunningApplication) Init() NSRunningApplication {
 	ret := C.NSRunningApplication_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15402,7 +15402,7 @@ func (x gen_NSScreen) ConvertRectToBacking(
 }
 
 // Init is undocumented.
-func (x gen_NSScreen) Init_AsNSScreen() NSScreen {
+func (x gen_NSScreen) Init() NSScreen {
 	ret := C.NSScreen_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15557,7 +15557,7 @@ func (x gen_NSStatusBar) StatusItemWithLength(
 }
 
 // Init is undocumented.
-func (x gen_NSStatusBar) Init_AsNSStatusBar() NSStatusBar {
+func (x gen_NSStatusBar) Init() NSStatusBar {
 	ret := C.NSStatusBar_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15607,7 +15607,7 @@ func NSStatusBarButton_FromRef(ref objc.Ref) NSStatusBarButton {
 }
 
 // Init is undocumented.
-func (x gen_NSStatusBarButton) Init_AsNSStatusBarButton() NSStatusBarButton {
+func (x gen_NSStatusBarButton) Init() NSStatusBarButton {
 	ret := C.NSStatusBarButton_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15660,7 +15660,7 @@ func NSStatusItem_FromRef(ref objc.Ref) NSStatusItem {
 }
 
 // Init is undocumented.
-func (x gen_NSStatusItem) Init_AsNSStatusItem() NSStatusItem {
+func (x gen_NSStatusItem) Init() NSStatusItem {
 	ret := C.NSStatusItem_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -16120,7 +16120,7 @@ func (x gen_NSText) WriteRTFDToFileAtomically(
 }
 
 // Init is undocumented.
-func (x gen_NSText) Init_AsNSText() NSText {
+func (x gen_NSText) Init() NSText {
 	ret := C.NSText_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -16601,7 +16601,7 @@ func (x gen_NSTextField) TextShouldEndEditing(
 }
 
 // Init is undocumented.
-func (x gen_NSTextField) Init_AsNSTextField() NSTextField {
+func (x gen_NSTextField) Init() NSTextField {
 	ret := C.NSTextField_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17093,7 +17093,7 @@ func (x gen_NSTextContainer) ReplaceLayoutManager(
 }
 
 // Init is undocumented.
-func (x gen_NSTextContainer) Init_AsNSTextContainer() NSTextContainer {
+func (x gen_NSTextContainer) Init() NSTextContainer {
 	ret := C.NSTextContainer_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17626,7 +17626,7 @@ func (x gen_NSViewController) ViewWillTransitionToSize(
 }
 
 // Init is undocumented.
-func (x gen_NSViewController) Init_AsNSViewController() NSViewController {
+func (x gen_NSViewController) Init() NSViewController {
 	ret := C.NSViewController_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17931,7 +17931,7 @@ func (x gen_NSVisualEffectView) ViewWillMoveToWindow(
 }
 
 // Init is undocumented.
-func (x gen_NSVisualEffectView) Init_AsNSVisualEffectView() NSVisualEffectView {
+func (x gen_NSVisualEffectView) Init() NSVisualEffectView {
 	ret := C.NSVisualEffectView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -19265,7 +19265,7 @@ func (x gen_NSWindow) Zoom(
 }
 
 // Init is undocumented.
-func (x gen_NSWindow) Init_AsNSWindow() NSWindow {
+func (x gen_NSWindow) Init() NSWindow {
 	ret := C.NSWindow_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -21215,7 +21215,7 @@ func (x gen_NSWorkspace) UnmountAndEjectDeviceAtPath(
 }
 
 // Init is undocumented.
-func (x gen_NSWorkspace) Init_AsNSWorkspace() NSWorkspace {
+func (x gen_NSWorkspace) Init() NSWorkspace {
 	ret := C.NSWorkspace_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -21494,7 +21494,7 @@ func (x gen_NSColor) WriteToPasteboard(
 }
 
 // Init is undocumented.
-func (x gen_NSColor) Init_AsNSColor() NSColor {
+func (x gen_NSColor) Init() NSColor {
 	ret := C.NSColor_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -22596,7 +22596,7 @@ func (x gen_NSTextView) WriteSelectionToPasteboardTypes(
 }
 
 // Init is undocumented.
-func (x gen_NSTextView) Init_AsNSTextView() NSTextView {
+func (x gen_NSTextView) Init() NSTextView {
 	ret := C.NSTextView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -25323,7 +25323,7 @@ func (x gen_NSView) WritePDFInsideRectToPasteboard(
 }
 
 // Init is undocumented.
-func (x gen_NSView) Init_AsNSView() NSView {
+func (x gen_NSView) Init() NSView {
 	ret := C.NSView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)

--- a/cocoa/cocoa_objc.gen.go
+++ b/cocoa/cocoa_objc.gen.go
@@ -8760,7 +8760,7 @@ func NSView_CompatibleWithResponsiveScrolling() bool {
 
 type NSBundleRef interface {
 	Pointer() uintptr
-	Init_AsNSBundle() NSBundle
+	Init() NSBundle
 }
 
 type gen_NSBundle struct {
@@ -8882,7 +8882,7 @@ func (x gen_NSBundle) URLsForResourcesWithExtensionSubdirectoryLocalization(
 // InitWithPath returns an NSBundle object initialized to correspond to the specified directory.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1412741-initwithpath?language=objc for details.
-func (x gen_NSBundle) InitWithPath_AsNSBundle(
+func (x gen_NSBundle) InitWithPath(
 	path core.NSStringRef,
 ) NSBundle {
 	ret := C.NSBundle_inst_InitWithPath(
@@ -8896,7 +8896,7 @@ func (x gen_NSBundle) InitWithPath_AsNSBundle(
 // InitWithURL returns an NSBundle object initialized to correspond to the specified file URL.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1409352-initwithurl?language=objc for details.
-func (x gen_NSBundle) InitWithURL_AsNSBundle(
+func (x gen_NSBundle) InitWithURL(
 	url core.NSURLRef,
 ) NSBundle {
 	ret := C.NSBundle_inst_InitWithURL(
@@ -9100,7 +9100,7 @@ func (x gen_NSBundle) Unload() bool {
 }
 
 // Init is undocumented.
-func (x gen_NSBundle) Init_AsNSBundle() NSBundle {
+func (x gen_NSBundle) Init() NSBundle {
 	ret := C.NSBundle_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -9363,7 +9363,7 @@ func (x gen_NSBundle) IsLoaded() bool {
 
 type NSSoundRef interface {
 	Pointer() uintptr
-	Init_AsNSSound() NSSound
+	Init() NSSound
 }
 
 type gen_NSSound struct {
@@ -9383,7 +9383,7 @@ func NSSound_FromRef(ref objc.Ref) NSSound {
 // InitWithContentsOfFileByReference initializes the receiver with the audio data located at a given filepath.
 //
 // See https://developer.apple.com/documentation/appkit/nssound/1477274-initwithcontentsoffile?language=objc for details.
-func (x gen_NSSound) InitWithContentsOfFileByReference_AsNSSound(
+func (x gen_NSSound) InitWithContentsOfFileByReference(
 	path core.NSStringRef,
 	byRef bool,
 ) NSSound {
@@ -9399,7 +9399,7 @@ func (x gen_NSSound) InitWithContentsOfFileByReference_AsNSSound(
 // InitWithContentsOfURLByReference initializes the receiver with the audio data located at a given URL.
 //
 // See https://developer.apple.com/documentation/appkit/nssound/1477288-initwithcontentsofurl?language=objc for details.
-func (x gen_NSSound) InitWithContentsOfURLByReference_AsNSSound(
+func (x gen_NSSound) InitWithContentsOfURLByReference(
 	url core.NSURLRef,
 	byRef bool,
 ) NSSound {
@@ -9415,7 +9415,7 @@ func (x gen_NSSound) InitWithContentsOfURLByReference_AsNSSound(
 // InitWithData initializes the receiver with a given audio data.
 //
 // See https://developer.apple.com/documentation/appkit/nssound/1477292-initwithdata?language=objc for details.
-func (x gen_NSSound) InitWithData_AsNSSound(
+func (x gen_NSSound) InitWithData(
 	data core.NSDataRef,
 ) NSSound {
 	ret := C.NSSound_inst_InitWithData(
@@ -9429,7 +9429,7 @@ func (x gen_NSSound) InitWithData_AsNSSound(
 // InitWithPasteboard initializes the receiver with data from a pasteboard. The pasteboard should contain a type returned by NSSound. NSSound expects the data to have a proper magic number, sound header, and data for the formats it supports.
 //
 // See https://developer.apple.com/documentation/appkit/nssound/1477294-initwithpasteboard?language=objc for details.
-func (x gen_NSSound) InitWithPasteboard_AsNSSound(
+func (x gen_NSSound) InitWithPasteboard(
 	pasteboard NSPasteboardRef,
 ) NSSound {
 	ret := C.NSSound_inst_InitWithPasteboard(
@@ -9499,7 +9499,7 @@ func (x gen_NSSound) WriteToPasteboard(
 }
 
 // Init is undocumented.
-func (x gen_NSSound) Init_AsNSSound() NSSound {
+func (x gen_NSSound) Init() NSSound {
 	ret := C.NSSound_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -9570,7 +9570,7 @@ func (x gen_NSSound) IsPlaying() bool {
 
 type NSApplicationRef interface {
 	Pointer() uintptr
-	Init_AsNSApplication() NSApplication
+	Init() NSApplication
 }
 
 type gen_NSApplication struct {
@@ -9954,7 +9954,7 @@ func (x gen_NSApplication) UnregisterUserInterfaceItemSearchHandler(
 }
 
 // Init is undocumented.
-func (x gen_NSApplication) Init_AsNSApplication() NSApplication {
+func (x gen_NSApplication) Init() NSApplication {
 	ret := C.NSApplication_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -10166,7 +10166,7 @@ func (x gen_NSApplication) SetMainMenu(
 
 type NSControlRef interface {
 	Pointer() uintptr
-	Init_AsNSControl() NSControl
+	Init() NSControl
 }
 
 type gen_NSControl struct {
@@ -10272,7 +10272,7 @@ func (x gen_NSControl) ExpansionFrameWithFrame(
 // InitWithFrame initializes a control with the specified frame rectangle.
 //
 // See https://developer.apple.com/documentation/appkit/nscontrol/1428900-initwithframe?language=objc for details.
-func (x gen_NSControl) InitWithFrame_AsNSControl(
+func (x gen_NSControl) InitWithFrame(
 	frameRect core.NSRect,
 ) NSControl {
 	ret := C.NSControl_inst_InitWithFrame(
@@ -10470,7 +10470,7 @@ func (x gen_NSControl) ValidateEditing() {
 }
 
 // Init is undocumented.
-func (x gen_NSControl) Init_AsNSControl() NSControl {
+func (x gen_NSControl) Init() NSControl {
 	ret := C.NSControl_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -10880,7 +10880,7 @@ func (x gen_NSControl) SetIgnoresMultiClick(
 
 type NSButtonRef interface {
 	Pointer() uintptr
-	Init_AsNSButton() NSButton
+	Init() NSButton
 }
 
 type gen_NSButton struct {
@@ -10965,7 +10965,7 @@ func (x gen_NSButton) SetNextState() {
 }
 
 // Init is undocumented.
-func (x gen_NSButton) Init_AsNSButton() NSButton {
+func (x gen_NSButton) Init() NSButton {
 	ret := C.NSButton_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -11450,7 +11450,7 @@ func (x gen_NSButton) SetKeyEquivalent(
 
 type NSEventRef interface {
 	Pointer() uintptr
-	Init_AsNSEvent() NSEvent
+	Init() NSEvent
 }
 
 type gen_NSEvent struct {
@@ -11468,7 +11468,7 @@ func NSEvent_FromRef(ref objc.Ref) NSEvent {
 }
 
 // Init is undocumented.
-func (x gen_NSEvent) Init_AsNSEvent() NSEvent {
+func (x gen_NSEvent) Init() NSEvent {
 	ret := C.NSEvent_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -11896,7 +11896,7 @@ func (x gen_NSEvent) IsDirectionInvertedFromDevice() bool {
 
 type NSFontRef interface {
 	Pointer() uintptr
-	Init_AsNSFont() NSFont
+	Init() NSFont
 }
 
 type gen_NSFont struct {
@@ -11939,7 +11939,7 @@ func (x gen_NSFont) Set() {
 }
 
 // Init is undocumented.
-func (x gen_NSFont) Init_AsNSFont() NSFont {
+func (x gen_NSFont) Init() NSFont {
 	ret := C.NSFont_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12048,7 +12048,7 @@ func (x gen_NSFont) VerticalFont() NSFont {
 
 type NSImageRef interface {
 	Pointer() uintptr
-	Init_AsNSImage() NSImage
+	Init() NSImage
 }
 
 type gen_NSImage struct {
@@ -12107,7 +12107,7 @@ func (x gen_NSImage) DrawInRect(
 // InitByReferencingFile initializes and returns an image object using the specified file.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519955-initbyreferencingfile?language=objc for details.
-func (x gen_NSImage) InitByReferencingFile_AsNSImage(
+func (x gen_NSImage) InitByReferencingFile(
 	fileName core.NSStringRef,
 ) NSImage {
 	ret := C.NSImage_inst_InitByReferencingFile(
@@ -12121,7 +12121,7 @@ func (x gen_NSImage) InitByReferencingFile_AsNSImage(
 // InitByReferencingURL initializes and returns an image object using the specified URL.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519990-initbyreferencingurl?language=objc for details.
-func (x gen_NSImage) InitByReferencingURL_AsNSImage(
+func (x gen_NSImage) InitByReferencingURL(
 	url core.NSURLRef,
 ) NSImage {
 	ret := C.NSImage_inst_InitByReferencingURL(
@@ -12135,7 +12135,7 @@ func (x gen_NSImage) InitByReferencingURL_AsNSImage(
 // InitWithContentsOfFile initializes and returns an image object with the contents of the specified file.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519918-initwithcontentsoffile?language=objc for details.
-func (x gen_NSImage) InitWithContentsOfFile_AsNSImage(
+func (x gen_NSImage) InitWithContentsOfFile(
 	fileName core.NSStringRef,
 ) NSImage {
 	ret := C.NSImage_inst_InitWithContentsOfFile(
@@ -12149,7 +12149,7 @@ func (x gen_NSImage) InitWithContentsOfFile_AsNSImage(
 // InitWithContentsOfURL initializes and returns an image object with the contents of the specified URL.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519907-initwithcontentsofurl?language=objc for details.
-func (x gen_NSImage) InitWithContentsOfURL_AsNSImage(
+func (x gen_NSImage) InitWithContentsOfURL(
 	url core.NSURLRef,
 ) NSImage {
 	ret := C.NSImage_inst_InitWithContentsOfURL(
@@ -12163,7 +12163,7 @@ func (x gen_NSImage) InitWithContentsOfURL_AsNSImage(
 // InitWithData initializes and returns an image object using the provided image data.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519941-initwithdata?language=objc for details.
-func (x gen_NSImage) InitWithData_AsNSImage(
+func (x gen_NSImage) InitWithData(
 	data core.NSDataRef,
 ) NSImage {
 	ret := C.NSImage_inst_InitWithData(
@@ -12177,7 +12177,7 @@ func (x gen_NSImage) InitWithData_AsNSImage(
 // InitWithDataIgnoringOrientation initializes and returns an image object using the provided image data and ignoring the EXIF orientation tags.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519915-initwithdataignoringorientation?language=objc for details.
-func (x gen_NSImage) InitWithDataIgnoringOrientation_AsNSImage(
+func (x gen_NSImage) InitWithDataIgnoringOrientation(
 	data core.NSDataRef,
 ) NSImage {
 	ret := C.NSImage_inst_InitWithDataIgnoringOrientation(
@@ -12191,7 +12191,7 @@ func (x gen_NSImage) InitWithDataIgnoringOrientation_AsNSImage(
 // InitWithPasteboard initializes and returns an image object with data from the specified pasteboard.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519952-initwithpasteboard?language=objc for details.
-func (x gen_NSImage) InitWithPasteboard_AsNSImage(
+func (x gen_NSImage) InitWithPasteboard(
 	pasteboard NSPasteboardRef,
 ) NSImage {
 	ret := C.NSImage_inst_InitWithPasteboard(
@@ -12205,7 +12205,7 @@ func (x gen_NSImage) InitWithPasteboard_AsNSImage(
 // InitWithSize initializes and returns an image object with the specified dimensions.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1520033-initwithsize?language=objc for details.
-func (x gen_NSImage) InitWithSize_AsNSImage(
+func (x gen_NSImage) InitWithSize(
 	size core.NSSize,
 ) NSImage {
 	ret := C.NSImage_inst_InitWithSize(
@@ -12303,7 +12303,7 @@ func (x gen_NSImage) UnlockFocus() {
 }
 
 // Init is undocumented.
-func (x gen_NSImage) Init_AsNSImage() NSImage {
+func (x gen_NSImage) Init() NSImage {
 	ret := C.NSImage_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12585,7 +12585,7 @@ func (x gen_NSImage) SetMatchesOnlyOnBestFittingAxis(
 
 type NSImageViewRef interface {
 	Pointer() uintptr
-	Init_AsNSImageView() NSImageView
+	Init() NSImageView
 }
 
 type gen_NSImageView struct {
@@ -12603,7 +12603,7 @@ func NSImageView_FromRef(ref objc.Ref) NSImageView {
 }
 
 // Init is undocumented.
-func (x gen_NSImageView) Init_AsNSImageView() NSImageView {
+func (x gen_NSImageView) Init() NSImageView {
 	ret := C.NSImageView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12738,7 +12738,7 @@ func (x gen_NSImageView) SetContentTintColor(
 
 type NSNibRef interface {
 	Pointer() uintptr
-	Init_AsNSNib() NSNib
+	Init() NSNib
 }
 
 type gen_NSNib struct {
@@ -12758,7 +12758,7 @@ func NSNib_FromRef(ref objc.Ref) NSNib {
 // InitWithNibDataBundle initializes an instance with nib data and specified bundle for locating resources.
 //
 // See https://developer.apple.com/documentation/appkit/nsnib/1535865-initwithnibdata?language=objc for details.
-func (x gen_NSNib) InitWithNibDataBundle_AsNSNib(
+func (x gen_NSNib) InitWithNibDataBundle(
 	nibData core.NSDataRef,
 	bundle NSBundleRef,
 ) NSNib {
@@ -12788,7 +12788,7 @@ func (x gen_NSNib) InstantiateWithOwnerTopLevelObjects(
 }
 
 // Init is undocumented.
-func (x gen_NSNib) Init_AsNSNib() NSNib {
+func (x gen_NSNib) Init() NSNib {
 	ret := C.NSNib_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12798,7 +12798,7 @@ func (x gen_NSNib) Init_AsNSNib() NSNib {
 
 type NSPasteboardRef interface {
 	Pointer() uintptr
-	Init_AsNSPasteboard() NSPasteboard
+	Init() NSPasteboard
 }
 
 type gen_NSPasteboard struct {
@@ -12944,7 +12944,7 @@ func (x gen_NSPasteboard) WriteObjects(
 }
 
 // Init is undocumented.
-func (x gen_NSPasteboard) Init_AsNSPasteboard() NSPasteboard {
+func (x gen_NSPasteboard) Init() NSPasteboard {
 	ret := C.NSPasteboard_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12987,7 +12987,7 @@ func (x gen_NSPasteboard) ChangeCount() core.NSInteger {
 
 type NSLayoutManagerRef interface {
 	Pointer() uintptr
-	Init_AsNSLayoutManager() NSLayoutManager
+	Init() NSLayoutManager
 }
 
 type gen_NSLayoutManager struct {
@@ -13157,7 +13157,7 @@ func (x gen_NSLayoutManager) GlyphIndexForCharacterAtIndex(
 // Init initializes a newly created layout manager object.
 //
 // See https://developer.apple.com/documentation/uikit/nslayoutmanager/1402975-init?language=objc for details.
-func (x gen_NSLayoutManager) Init_AsNSLayoutManager() NSLayoutManager {
+func (x gen_NSLayoutManager) Init() NSLayoutManager {
 	ret := C.NSLayoutManager_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -13619,7 +13619,7 @@ func (x gen_NSLayoutManager) TextViewForBeginningOfSelection() NSTextView {
 
 type NSMenuRef interface {
 	Pointer() uintptr
-	Init_AsNSMenu() NSMenu
+	Init() NSMenu
 }
 
 type gen_NSMenu struct {
@@ -13779,7 +13779,7 @@ func (x gen_NSMenu) IndexOfItemWithTitle(
 // InitWithTitle initializes and returns a menu having the specified title and with autoenabling of menu items turned on.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenu/1518144-initwithtitle?language=objc for details.
-func (x gen_NSMenu) InitWithTitle_AsNSMenu(
+func (x gen_NSMenu) InitWithTitle(
 	title core.NSStringRef,
 ) NSMenu {
 	ret := C.NSMenu_inst_InitWithTitle(
@@ -14009,7 +14009,7 @@ func (x gen_NSMenu) Update() {
 }
 
 // Init is undocumented.
-func (x gen_NSMenu) Init_AsNSMenu() NSMenu {
+func (x gen_NSMenu) Init() NSMenu {
 	ret := C.NSMenu_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -14288,7 +14288,7 @@ func (x gen_NSMenu) SetDelegate(
 
 type NSPopoverRef interface {
 	Pointer() uintptr
-	Init_AsNSPopover() NSPopover
+	Init() NSPopover
 }
 
 type gen_NSPopover struct {
@@ -14319,7 +14319,7 @@ func (x gen_NSPopover) Close() {
 // Init is undocumented.
 //
 // See https://developer.apple.com/documentation/appkit/nspopover/1526851-init?language=objc for details.
-func (x gen_NSPopover) Init_AsNSPopover() NSPopover {
+func (x gen_NSPopover) Init() NSPopover {
 	ret := C.NSPopover_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -14465,7 +14465,7 @@ func (x gen_NSPopover) IsDetached() bool {
 
 type NSMenuItemRef interface {
 	Pointer() uintptr
-	Init_AsNSMenuItem() NSMenuItem
+	Init() NSMenuItem
 }
 
 type gen_NSMenuItem struct {
@@ -14485,7 +14485,7 @@ func NSMenuItem_FromRef(ref objc.Ref) NSMenuItem {
 // InitWithTitleActionKeyEquivalent returns an initialized instance of NSMenuItem.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenuitem/1514858-initwithtitle?language=objc for details.
-func (x gen_NSMenuItem) InitWithTitleActionKeyEquivalent_AsNSMenuItem(
+func (x gen_NSMenuItem) InitWithTitleActionKeyEquivalent(
 	string core.NSStringRef,
 	selector objc.Selector,
 	charCode core.NSStringRef,
@@ -14501,7 +14501,7 @@ func (x gen_NSMenuItem) InitWithTitleActionKeyEquivalent_AsNSMenuItem(
 }
 
 // Init is undocumented.
-func (x gen_NSMenuItem) Init_AsNSMenuItem() NSMenuItem {
+func (x gen_NSMenuItem) Init() NSMenuItem {
 	ret := C.NSMenuItem_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15152,7 +15152,7 @@ func (x gen_NSMenuItem) SetAllowsKeyEquivalentWhenHidden(
 
 type NSRunningApplicationRef interface {
 	Pointer() uintptr
-	Init_AsNSRunningApplication() NSRunningApplication
+	Init() NSRunningApplication
 }
 
 type gen_NSRunningApplication struct {
@@ -15214,7 +15214,7 @@ func (x gen_NSRunningApplication) Unhide() bool {
 }
 
 // Init is undocumented.
-func (x gen_NSRunningApplication) Init_AsNSRunningApplication() NSRunningApplication {
+func (x gen_NSRunningApplication) Init() NSRunningApplication {
 	ret := C.NSRunningApplication_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15356,7 +15356,7 @@ func (x gen_NSRunningApplication) IsTerminated() bool {
 
 type NSScreenRef interface {
 	Pointer() uintptr
-	Init_AsNSScreen() NSScreen
+	Init() NSScreen
 }
 
 type gen_NSScreen struct {
@@ -15402,7 +15402,7 @@ func (x gen_NSScreen) ConvertRectToBacking(
 }
 
 // Init is undocumented.
-func (x gen_NSScreen) Init_AsNSScreen() NSScreen {
+func (x gen_NSScreen) Init() NSScreen {
 	ret := C.NSScreen_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15511,7 +15511,7 @@ func (x gen_NSScreen) MaximumFramesPerSecond() core.NSInteger {
 
 type NSStatusBarRef interface {
 	Pointer() uintptr
-	Init_AsNSStatusBar() NSStatusBar
+	Init() NSStatusBar
 }
 
 type gen_NSStatusBar struct {
@@ -15557,7 +15557,7 @@ func (x gen_NSStatusBar) StatusItemWithLength(
 }
 
 // Init is undocumented.
-func (x gen_NSStatusBar) Init_AsNSStatusBar() NSStatusBar {
+func (x gen_NSStatusBar) Init() NSStatusBar {
 	ret := C.NSStatusBar_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15589,7 +15589,7 @@ func (x gen_NSStatusBar) Thickness() core.CGFloat {
 
 type NSStatusBarButtonRef interface {
 	Pointer() uintptr
-	Init_AsNSStatusBarButton() NSStatusBarButton
+	Init() NSStatusBarButton
 }
 
 type gen_NSStatusBarButton struct {
@@ -15607,7 +15607,7 @@ func NSStatusBarButton_FromRef(ref objc.Ref) NSStatusBarButton {
 }
 
 // Init is undocumented.
-func (x gen_NSStatusBarButton) Init_AsNSStatusBarButton() NSStatusBarButton {
+func (x gen_NSStatusBarButton) Init() NSStatusBarButton {
 	ret := C.NSStatusBarButton_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15642,7 +15642,7 @@ func (x gen_NSStatusBarButton) SetAppearsDisabled(
 
 type NSStatusItemRef interface {
 	Pointer() uintptr
-	Init_AsNSStatusItem() NSStatusItem
+	Init() NSStatusItem
 }
 
 type gen_NSStatusItem struct {
@@ -15660,7 +15660,7 @@ func NSStatusItem_FromRef(ref objc.Ref) NSStatusItem {
 }
 
 // Init is undocumented.
-func (x gen_NSStatusItem) Init_AsNSStatusItem() NSStatusItem {
+func (x gen_NSStatusItem) Init() NSStatusItem {
 	ret := C.NSStatusItem_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15767,7 +15767,7 @@ func (x gen_NSStatusItem) SetLength(
 
 type NSTextRef interface {
 	Pointer() uintptr
-	Init_AsNSText() NSText
+	Init() NSText
 }
 
 type gen_NSText struct {
@@ -15927,7 +15927,7 @@ func (x gen_NSText) Delete(
 // InitWithFrame is undocumented.
 //
 // See https://developer.apple.com/documentation/appkit/nstext/1525191-initwithframe?language=objc for details.
-func (x gen_NSText) InitWithFrame_AsNSText(
+func (x gen_NSText) InitWithFrame(
 	frameRect core.NSRect,
 ) NSText {
 	ret := C.NSText_inst_InitWithFrame(
@@ -16120,7 +16120,7 @@ func (x gen_NSText) WriteRTFDToFileAtomically(
 }
 
 // Init is undocumented.
-func (x gen_NSText) Init_AsNSText() NSText {
+func (x gen_NSText) Init() NSText {
 	ret := C.NSText_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -16541,7 +16541,7 @@ func (x gen_NSText) SetDelegate(
 
 type NSTextFieldRef interface {
 	Pointer() uintptr
-	Init_AsNSTextField() NSTextField
+	Init() NSTextField
 }
 
 type gen_NSTextField struct {
@@ -16601,7 +16601,7 @@ func (x gen_NSTextField) TextShouldEndEditing(
 }
 
 // Init is undocumented.
-func (x gen_NSTextField) Init_AsNSTextField() NSTextField {
+func (x gen_NSTextField) Init() NSTextField {
 	ret := C.NSTextField_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17047,7 +17047,7 @@ func (x gen_NSTextField) SetDelegate(
 
 type NSTextContainerRef interface {
 	Pointer() uintptr
-	Init_AsNSTextContainer() NSTextContainer
+	Init() NSTextContainer
 }
 
 type gen_NSTextContainer struct {
@@ -17067,7 +17067,7 @@ func NSTextContainer_FromRef(ref objc.Ref) NSTextContainer {
 // InitWithSize initializes a text container with a specified bounding rectangle.
 //
 // See https://developer.apple.com/documentation/uikit/nstextcontainer/1444529-initwithsize?language=objc for details.
-func (x gen_NSTextContainer) InitWithSize_AsNSTextContainer(
+func (x gen_NSTextContainer) InitWithSize(
 	size core.NSSize,
 ) NSTextContainer {
 	ret := C.NSTextContainer_inst_InitWithSize(
@@ -17093,7 +17093,7 @@ func (x gen_NSTextContainer) ReplaceLayoutManager(
 }
 
 // Init is undocumented.
-func (x gen_NSTextContainer) Init_AsNSTextContainer() NSTextContainer {
+func (x gen_NSTextContainer) Init() NSTextContainer {
 	ret := C.NSTextContainer_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17314,7 +17314,7 @@ func (x gen_NSTextContainer) IsSimpleRectangularTextContainer() bool {
 
 type NSViewControllerRef interface {
 	Pointer() uintptr
-	Init_AsNSViewController() NSViewController
+	Init() NSViewController
 }
 
 type gen_NSViewController struct {
@@ -17626,7 +17626,7 @@ func (x gen_NSViewController) ViewWillTransitionToSize(
 }
 
 // Init is undocumented.
-func (x gen_NSViewController) Init_AsNSViewController() NSViewController {
+func (x gen_NSViewController) Init() NSViewController {
 	ret := C.NSViewController_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17888,7 +17888,7 @@ func (x gen_NSViewController) SetSourceItemView(
 
 type NSVisualEffectViewRef interface {
 	Pointer() uintptr
-	Init_AsNSVisualEffectView() NSVisualEffectView
+	Init() NSVisualEffectView
 }
 
 type gen_NSVisualEffectView struct {
@@ -17931,7 +17931,7 @@ func (x gen_NSVisualEffectView) ViewWillMoveToWindow(
 }
 
 // Init is undocumented.
-func (x gen_NSVisualEffectView) Init_AsNSVisualEffectView() NSVisualEffectView {
+func (x gen_NSVisualEffectView) Init() NSVisualEffectView {
 	ret := C.NSVisualEffectView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17991,7 +17991,7 @@ func (x gen_NSVisualEffectView) SetMaskImage(
 
 type NSWindowRef interface {
 	Pointer() uintptr
-	Init_AsNSWindow() NSWindow
+	Init() NSWindow
 }
 
 type gen_NSWindow struct {
@@ -18479,7 +18479,7 @@ func (x gen_NSWindow) FrameRectForContentRect(
 // InitWithContentRectStyleMaskBackingDefer initializes the window with the specified values.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/1419477-initwithcontentrect?language=objc for details.
-func (x gen_NSWindow) InitWithContentRectStyleMaskBackingDefer_AsNSWindow(
+func (x gen_NSWindow) InitWithContentRectStyleMaskBackingDefer(
 	contentRect core.NSRect,
 	style core.NSUInteger,
 	backingStoreType core.NSUInteger,
@@ -18499,7 +18499,7 @@ func (x gen_NSWindow) InitWithContentRectStyleMaskBackingDefer_AsNSWindow(
 // InitWithContentRectStyleMaskBackingDeferScreen initializes an allocated window with the specified values.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/1419755-initwithcontentrect?language=objc for details.
-func (x gen_NSWindow) InitWithContentRectStyleMaskBackingDeferScreen_AsNSWindow(
+func (x gen_NSWindow) InitWithContentRectStyleMaskBackingDeferScreen(
 	contentRect core.NSRect,
 	style core.NSUInteger,
 	backingStoreType core.NSUInteger,
@@ -19265,7 +19265,7 @@ func (x gen_NSWindow) Zoom(
 }
 
 // Init is undocumented.
-func (x gen_NSWindow) Init_AsNSWindow() NSWindow {
+func (x gen_NSWindow) Init() NSWindow {
 	ret := C.NSWindow_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -20960,7 +20960,7 @@ func (x gen_NSWindow) SetOrderedIndex(
 
 type NSWorkspaceRef interface {
 	Pointer() uintptr
-	Init_AsNSWorkspace() NSWorkspace
+	Init() NSWorkspace
 }
 
 type gen_NSWorkspace struct {
@@ -21215,7 +21215,7 @@ func (x gen_NSWorkspace) UnmountAndEjectDeviceAtPath(
 }
 
 // Init is undocumented.
-func (x gen_NSWorkspace) Init_AsNSWorkspace() NSWorkspace {
+func (x gen_NSWorkspace) Init() NSWorkspace {
 	ret := C.NSWorkspace_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -21357,7 +21357,7 @@ func (x gen_NSWorkspace) IsVoiceOverEnabled() bool {
 
 type NSColorRef interface {
 	Pointer() uintptr
-	Init_AsNSColor() NSColor
+	Init() NSColor
 }
 
 type gen_NSColor struct {
@@ -21494,7 +21494,7 @@ func (x gen_NSColor) WriteToPasteboard(
 }
 
 // Init is undocumented.
-func (x gen_NSColor) Init_AsNSColor() NSColor {
+func (x gen_NSColor) Init() NSColor {
 	ret := C.NSColor_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -21669,7 +21669,7 @@ func (x gen_NSColor) LocalizedColorNameComponent() core.NSString {
 
 type NSTextViewRef interface {
 	Pointer() uintptr
-	Init_AsNSTextView() NSTextView
+	Init() NSTextView
 }
 
 type gen_NSTextView struct {
@@ -21914,7 +21914,7 @@ func (x gen_NSTextView) DrawViewBackgroundInRect(
 // InitWithFrame initializes a text view.
 //
 // See https://developer.apple.com/documentation/appkit/nstextview/1449262-initwithframe?language=objc for details.
-func (x gen_NSTextView) InitWithFrame_AsNSTextView(
+func (x gen_NSTextView) InitWithFrame(
 	frameRect core.NSRect,
 ) NSTextView {
 	ret := C.NSTextView_inst_InitWithFrame(
@@ -21928,7 +21928,7 @@ func (x gen_NSTextView) InitWithFrame_AsNSTextView(
 // InitWithFrameTextContainer initializes a text view.
 //
 // See https://developer.apple.com/documentation/appkit/nstextview/1449347-initwithframe?language=objc for details.
-func (x gen_NSTextView) InitWithFrameTextContainer_AsNSTextView(
+func (x gen_NSTextView) InitWithFrameTextContainer(
 	frameRect core.NSRect,
 	container NSTextContainerRef,
 ) NSTextView {
@@ -22596,7 +22596,7 @@ func (x gen_NSTextView) WriteSelectionToPasteboardTypes(
 }
 
 // Init is undocumented.
-func (x gen_NSTextView) Init_AsNSTextView() NSTextView {
+func (x gen_NSTextView) Init() NSTextView {
 	ret := C.NSTextView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -23798,7 +23798,7 @@ func (x gen_NSTextView) SetFont(
 
 type NSViewRef interface {
 	Pointer() uintptr
-	Init_AsNSView() NSView
+	Init() NSView
 }
 
 type gen_NSView struct {
@@ -24527,7 +24527,7 @@ func (x gen_NSView) HitTest(
 // InitWithFrame initializes and returns a newly allocated NSView object with a specified frame rectangle.
 //
 // See https://developer.apple.com/documentation/appkit/nsview/1483458-initwithframe?language=objc for details.
-func (x gen_NSView) InitWithFrame_AsNSView(
+func (x gen_NSView) InitWithFrame(
 	frameRect core.NSRect,
 ) NSView {
 	ret := C.NSView_inst_InitWithFrame(
@@ -25323,7 +25323,7 @@ func (x gen_NSView) WritePDFInsideRectToPasteboard(
 }
 
 // Init is undocumented.
-func (x gen_NSView) Init_AsNSView() NSView {
+func (x gen_NSView) Init() NSView {
 	ret := C.NSView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)

--- a/cocoa/cocoa_objc.gen.go
+++ b/cocoa/cocoa_objc.gen.go
@@ -9099,8 +9099,17 @@ func (x gen_NSBundle) Unload() bool {
 	return convertObjCBoolToGo(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSBundle class.
 func (x gen_NSBundle) Init() NSBundle {
+	ret := C.NSBundle_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSBundle_FromPointer(ret)
+}
+
+// Init_AsNSBundle is a typed version of Init.
+func (x gen_NSBundle) Init_AsNSBundle() NSBundle {
 	ret := C.NSBundle_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -9498,8 +9507,17 @@ func (x gen_NSSound) WriteToPasteboard(
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSSound class.
 func (x gen_NSSound) Init() NSSound {
+	ret := C.NSSound_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSSound_FromPointer(ret)
+}
+
+// Init_AsNSSound is a typed version of Init.
+func (x gen_NSSound) Init_AsNSSound() NSSound {
 	ret := C.NSSound_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -9953,8 +9971,17 @@ func (x gen_NSApplication) UnregisterUserInterfaceItemSearchHandler(
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSApplication class.
 func (x gen_NSApplication) Init() NSApplication {
+	ret := C.NSApplication_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSApplication_FromPointer(ret)
+}
+
+// Init_AsNSApplication is a typed version of Init.
+func (x gen_NSApplication) Init_AsNSApplication() NSApplication {
 	ret := C.NSApplication_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -10469,8 +10496,17 @@ func (x gen_NSControl) ValidateEditing() {
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSControl class.
 func (x gen_NSControl) Init() NSControl {
+	ret := C.NSControl_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSControl_FromPointer(ret)
+}
+
+// Init_AsNSControl is a typed version of Init.
+func (x gen_NSControl) Init_AsNSControl() NSControl {
 	ret := C.NSControl_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -10964,8 +11000,17 @@ func (x gen_NSButton) SetNextState() {
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSButton class.
 func (x gen_NSButton) Init() NSButton {
+	ret := C.NSButton_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSButton_FromPointer(ret)
+}
+
+// Init_AsNSButton is a typed version of Init.
+func (x gen_NSButton) Init_AsNSButton() NSButton {
 	ret := C.NSButton_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -11467,8 +11512,17 @@ func NSEvent_FromRef(ref objc.Ref) NSEvent {
 	return NSEvent_FromPointer(unsafe.Pointer(ref.Pointer()))
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSEvent class.
 func (x gen_NSEvent) Init() NSEvent {
+	ret := C.NSEvent_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSEvent_FromPointer(ret)
+}
+
+// Init_AsNSEvent is a typed version of Init.
+func (x gen_NSEvent) Init_AsNSEvent() NSEvent {
 	ret := C.NSEvent_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -11938,8 +11992,17 @@ func (x gen_NSFont) Set() {
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSFont class.
 func (x gen_NSFont) Init() NSFont {
+	ret := C.NSFont_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSFont_FromPointer(ret)
+}
+
+// Init_AsNSFont is a typed version of Init.
+func (x gen_NSFont) Init_AsNSFont() NSFont {
 	ret := C.NSFont_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12302,8 +12365,17 @@ func (x gen_NSImage) UnlockFocus() {
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSImage class.
 func (x gen_NSImage) Init() NSImage {
+	ret := C.NSImage_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSImage_FromPointer(ret)
+}
+
+// Init_AsNSImage is a typed version of Init.
+func (x gen_NSImage) Init_AsNSImage() NSImage {
 	ret := C.NSImage_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12602,8 +12674,17 @@ func NSImageView_FromRef(ref objc.Ref) NSImageView {
 	return NSImageView_FromPointer(unsafe.Pointer(ref.Pointer()))
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSImageView class.
 func (x gen_NSImageView) Init() NSImageView {
+	ret := C.NSImageView_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSImageView_FromPointer(ret)
+}
+
+// Init_AsNSImageView is a typed version of Init.
+func (x gen_NSImageView) Init_AsNSImageView() NSImageView {
 	ret := C.NSImageView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12787,8 +12868,17 @@ func (x gen_NSNib) InstantiateWithOwnerTopLevelObjects(
 	return convertObjCBoolToGo(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSNib class.
 func (x gen_NSNib) Init() NSNib {
+	ret := C.NSNib_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSNib_FromPointer(ret)
+}
+
+// Init_AsNSNib is a typed version of Init.
+func (x gen_NSNib) Init_AsNSNib() NSNib {
 	ret := C.NSNib_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12943,8 +13033,17 @@ func (x gen_NSPasteboard) WriteObjects(
 	return convertObjCBoolToGo(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSPasteboard class.
 func (x gen_NSPasteboard) Init() NSPasteboard {
+	ret := C.NSPasteboard_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSPasteboard_FromPointer(ret)
+}
+
+// Init_AsNSPasteboard is a typed version of Init.
+func (x gen_NSPasteboard) Init_AsNSPasteboard() NSPasteboard {
 	ret := C.NSPasteboard_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -13158,6 +13257,17 @@ func (x gen_NSLayoutManager) GlyphIndexForCharacterAtIndex(
 //
 // See https://developer.apple.com/documentation/uikit/nslayoutmanager/1402975-init?language=objc for details.
 func (x gen_NSLayoutManager) Init() NSLayoutManager {
+	ret := C.NSLayoutManager_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSLayoutManager_FromPointer(ret)
+}
+
+// Init_AsNSLayoutManager is a typed version of Init.
+//
+// See https://developer.apple.com/documentation/uikit/nslayoutmanager/1402975-init?language=objc for details.
+func (x gen_NSLayoutManager) Init_AsNSLayoutManager() NSLayoutManager {
 	ret := C.NSLayoutManager_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -14008,8 +14118,17 @@ func (x gen_NSMenu) Update() {
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSMenu class.
 func (x gen_NSMenu) Init() NSMenu {
+	ret := C.NSMenu_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSMenu_FromPointer(ret)
+}
+
+// Init_AsNSMenu is a typed version of Init.
+func (x gen_NSMenu) Init_AsNSMenu() NSMenu {
 	ret := C.NSMenu_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -14316,10 +14435,21 @@ func (x gen_NSPopover) Close() {
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSPopover class.
 //
 // See https://developer.apple.com/documentation/appkit/nspopover/1526851-init?language=objc for details.
 func (x gen_NSPopover) Init() NSPopover {
+	ret := C.NSPopover_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSPopover_FromPointer(ret)
+}
+
+// Init_AsNSPopover is a typed version of Init.
+//
+// See https://developer.apple.com/documentation/appkit/nspopover/1526851-init?language=objc for details.
+func (x gen_NSPopover) Init_AsNSPopover() NSPopover {
 	ret := C.NSPopover_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -14500,8 +14630,17 @@ func (x gen_NSMenuItem) InitWithTitleActionKeyEquivalent(
 	return NSMenuItem_FromPointer(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSMenuItem class.
 func (x gen_NSMenuItem) Init() NSMenuItem {
+	ret := C.NSMenuItem_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSMenuItem_FromPointer(ret)
+}
+
+// Init_AsNSMenuItem is a typed version of Init.
+func (x gen_NSMenuItem) Init_AsNSMenuItem() NSMenuItem {
 	ret := C.NSMenuItem_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15213,8 +15352,17 @@ func (x gen_NSRunningApplication) Unhide() bool {
 	return convertObjCBoolToGo(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSRunningApplication class.
 func (x gen_NSRunningApplication) Init() NSRunningApplication {
+	ret := C.NSRunningApplication_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSRunningApplication_FromPointer(ret)
+}
+
+// Init_AsNSRunningApplication is a typed version of Init.
+func (x gen_NSRunningApplication) Init_AsNSRunningApplication() NSRunningApplication {
 	ret := C.NSRunningApplication_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15401,8 +15549,17 @@ func (x gen_NSScreen) ConvertRectToBacking(
 	return *(*core.NSRect)(unsafe.Pointer(&ret))
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSScreen class.
 func (x gen_NSScreen) Init() NSScreen {
+	ret := C.NSScreen_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSScreen_FromPointer(ret)
+}
+
+// Init_AsNSScreen is a typed version of Init.
+func (x gen_NSScreen) Init_AsNSScreen() NSScreen {
 	ret := C.NSScreen_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15556,8 +15713,17 @@ func (x gen_NSStatusBar) StatusItemWithLength(
 	return NSStatusItem_FromPointer(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSStatusBar class.
 func (x gen_NSStatusBar) Init() NSStatusBar {
+	ret := C.NSStatusBar_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSStatusBar_FromPointer(ret)
+}
+
+// Init_AsNSStatusBar is a typed version of Init.
+func (x gen_NSStatusBar) Init_AsNSStatusBar() NSStatusBar {
 	ret := C.NSStatusBar_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15606,8 +15772,17 @@ func NSStatusBarButton_FromRef(ref objc.Ref) NSStatusBarButton {
 	return NSStatusBarButton_FromPointer(unsafe.Pointer(ref.Pointer()))
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSStatusBarButton class.
 func (x gen_NSStatusBarButton) Init() NSStatusBarButton {
+	ret := C.NSStatusBarButton_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSStatusBarButton_FromPointer(ret)
+}
+
+// Init_AsNSStatusBarButton is a typed version of Init.
+func (x gen_NSStatusBarButton) Init_AsNSStatusBarButton() NSStatusBarButton {
 	ret := C.NSStatusBarButton_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15659,8 +15834,17 @@ func NSStatusItem_FromRef(ref objc.Ref) NSStatusItem {
 	return NSStatusItem_FromPointer(unsafe.Pointer(ref.Pointer()))
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSStatusItem class.
 func (x gen_NSStatusItem) Init() NSStatusItem {
+	ret := C.NSStatusItem_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSStatusItem_FromPointer(ret)
+}
+
+// Init_AsNSStatusItem is a typed version of Init.
+func (x gen_NSStatusItem) Init_AsNSStatusItem() NSStatusItem {
 	ret := C.NSStatusItem_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -16119,8 +16303,17 @@ func (x gen_NSText) WriteRTFDToFileAtomically(
 	return convertObjCBoolToGo(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSText class.
 func (x gen_NSText) Init() NSText {
+	ret := C.NSText_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSText_FromPointer(ret)
+}
+
+// Init_AsNSText is a typed version of Init.
+func (x gen_NSText) Init_AsNSText() NSText {
 	ret := C.NSText_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -16600,8 +16793,17 @@ func (x gen_NSTextField) TextShouldEndEditing(
 	return convertObjCBoolToGo(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSTextField class.
 func (x gen_NSTextField) Init() NSTextField {
+	ret := C.NSTextField_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSTextField_FromPointer(ret)
+}
+
+// Init_AsNSTextField is a typed version of Init.
+func (x gen_NSTextField) Init_AsNSTextField() NSTextField {
 	ret := C.NSTextField_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17092,8 +17294,17 @@ func (x gen_NSTextContainer) ReplaceLayoutManager(
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSTextContainer class.
 func (x gen_NSTextContainer) Init() NSTextContainer {
+	ret := C.NSTextContainer_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSTextContainer_FromPointer(ret)
+}
+
+// Init_AsNSTextContainer is a typed version of Init.
+func (x gen_NSTextContainer) Init_AsNSTextContainer() NSTextContainer {
 	ret := C.NSTextContainer_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17625,8 +17836,17 @@ func (x gen_NSViewController) ViewWillTransitionToSize(
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSViewController class.
 func (x gen_NSViewController) Init() NSViewController {
+	ret := C.NSViewController_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSViewController_FromPointer(ret)
+}
+
+// Init_AsNSViewController is a typed version of Init.
+func (x gen_NSViewController) Init_AsNSViewController() NSViewController {
 	ret := C.NSViewController_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17930,8 +18150,17 @@ func (x gen_NSVisualEffectView) ViewWillMoveToWindow(
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSVisualEffectView class.
 func (x gen_NSVisualEffectView) Init() NSVisualEffectView {
+	ret := C.NSVisualEffectView_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSVisualEffectView_FromPointer(ret)
+}
+
+// Init_AsNSVisualEffectView is a typed version of Init.
+func (x gen_NSVisualEffectView) Init_AsNSVisualEffectView() NSVisualEffectView {
 	ret := C.NSVisualEffectView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -19264,8 +19493,17 @@ func (x gen_NSWindow) Zoom(
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSWindow class.
 func (x gen_NSWindow) Init() NSWindow {
+	ret := C.NSWindow_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSWindow_FromPointer(ret)
+}
+
+// Init_AsNSWindow is a typed version of Init.
+func (x gen_NSWindow) Init_AsNSWindow() NSWindow {
 	ret := C.NSWindow_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -21214,8 +21452,17 @@ func (x gen_NSWorkspace) UnmountAndEjectDeviceAtPath(
 	return convertObjCBoolToGo(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSWorkspace class.
 func (x gen_NSWorkspace) Init() NSWorkspace {
+	ret := C.NSWorkspace_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSWorkspace_FromPointer(ret)
+}
+
+// Init_AsNSWorkspace is a typed version of Init.
+func (x gen_NSWorkspace) Init_AsNSWorkspace() NSWorkspace {
 	ret := C.NSWorkspace_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -21493,8 +21740,17 @@ func (x gen_NSColor) WriteToPasteboard(
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSColor class.
 func (x gen_NSColor) Init() NSColor {
+	ret := C.NSColor_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSColor_FromPointer(ret)
+}
+
+// Init_AsNSColor is a typed version of Init.
+func (x gen_NSColor) Init_AsNSColor() NSColor {
 	ret := C.NSColor_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -22595,8 +22851,17 @@ func (x gen_NSTextView) WriteSelectionToPasteboardTypes(
 	return convertObjCBoolToGo(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSTextView class.
 func (x gen_NSTextView) Init() NSTextView {
+	ret := C.NSTextView_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSTextView_FromPointer(ret)
+}
+
+// Init_AsNSTextView is a typed version of Init.
+func (x gen_NSTextView) Init_AsNSTextView() NSTextView {
 	ret := C.NSTextView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -25322,8 +25587,17 @@ func (x gen_NSView) WritePDFInsideRectToPasteboard(
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSView class.
 func (x gen_NSView) Init() NSView {
+	ret := C.NSView_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSView_FromPointer(ret)
+}
+
+// Init_AsNSView is a typed version of Init.
+func (x gen_NSView) Init_AsNSView() NSView {
 	ret := C.NSView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)

--- a/cocoa/cocoa_objc.gen.go
+++ b/cocoa/cocoa_objc.gen.go
@@ -8760,7 +8760,7 @@ func NSView_CompatibleWithResponsiveScrolling() bool {
 
 type NSBundleRef interface {
 	Pointer() uintptr
-	Init() NSBundle
+	Init_AsNSBundle() NSBundle
 }
 
 type gen_NSBundle struct {
@@ -9100,7 +9100,7 @@ func (x gen_NSBundle) Unload() bool {
 }
 
 // Init is undocumented.
-func (x gen_NSBundle) Init() NSBundle {
+func (x gen_NSBundle) Init_AsNSBundle() NSBundle {
 	ret := C.NSBundle_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -9363,7 +9363,7 @@ func (x gen_NSBundle) IsLoaded() bool {
 
 type NSSoundRef interface {
 	Pointer() uintptr
-	Init() NSSound
+	Init_AsNSSound() NSSound
 }
 
 type gen_NSSound struct {
@@ -9499,7 +9499,7 @@ func (x gen_NSSound) WriteToPasteboard(
 }
 
 // Init is undocumented.
-func (x gen_NSSound) Init() NSSound {
+func (x gen_NSSound) Init_AsNSSound() NSSound {
 	ret := C.NSSound_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -9570,7 +9570,7 @@ func (x gen_NSSound) IsPlaying() bool {
 
 type NSApplicationRef interface {
 	Pointer() uintptr
-	Init() NSApplication
+	Init_AsNSApplication() NSApplication
 }
 
 type gen_NSApplication struct {
@@ -9954,7 +9954,7 @@ func (x gen_NSApplication) UnregisterUserInterfaceItemSearchHandler(
 }
 
 // Init is undocumented.
-func (x gen_NSApplication) Init() NSApplication {
+func (x gen_NSApplication) Init_AsNSApplication() NSApplication {
 	ret := C.NSApplication_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -10166,7 +10166,7 @@ func (x gen_NSApplication) SetMainMenu(
 
 type NSControlRef interface {
 	Pointer() uintptr
-	Init() NSControl
+	Init_AsNSControl() NSControl
 }
 
 type gen_NSControl struct {
@@ -10470,7 +10470,7 @@ func (x gen_NSControl) ValidateEditing() {
 }
 
 // Init is undocumented.
-func (x gen_NSControl) Init() NSControl {
+func (x gen_NSControl) Init_AsNSControl() NSControl {
 	ret := C.NSControl_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -10880,7 +10880,7 @@ func (x gen_NSControl) SetIgnoresMultiClick(
 
 type NSButtonRef interface {
 	Pointer() uintptr
-	Init() NSButton
+	Init_AsNSButton() NSButton
 }
 
 type gen_NSButton struct {
@@ -10965,7 +10965,7 @@ func (x gen_NSButton) SetNextState() {
 }
 
 // Init is undocumented.
-func (x gen_NSButton) Init() NSButton {
+func (x gen_NSButton) Init_AsNSButton() NSButton {
 	ret := C.NSButton_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -11450,7 +11450,7 @@ func (x gen_NSButton) SetKeyEquivalent(
 
 type NSEventRef interface {
 	Pointer() uintptr
-	Init() NSEvent
+	Init_AsNSEvent() NSEvent
 }
 
 type gen_NSEvent struct {
@@ -11468,7 +11468,7 @@ func NSEvent_FromRef(ref objc.Ref) NSEvent {
 }
 
 // Init is undocumented.
-func (x gen_NSEvent) Init() NSEvent {
+func (x gen_NSEvent) Init_AsNSEvent() NSEvent {
 	ret := C.NSEvent_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -11896,7 +11896,7 @@ func (x gen_NSEvent) IsDirectionInvertedFromDevice() bool {
 
 type NSFontRef interface {
 	Pointer() uintptr
-	Init() NSFont
+	Init_AsNSFont() NSFont
 }
 
 type gen_NSFont struct {
@@ -11939,7 +11939,7 @@ func (x gen_NSFont) Set() {
 }
 
 // Init is undocumented.
-func (x gen_NSFont) Init() NSFont {
+func (x gen_NSFont) Init_AsNSFont() NSFont {
 	ret := C.NSFont_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12048,7 +12048,7 @@ func (x gen_NSFont) VerticalFont() NSFont {
 
 type NSImageRef interface {
 	Pointer() uintptr
-	Init() NSImage
+	Init_AsNSImage() NSImage
 }
 
 type gen_NSImage struct {
@@ -12303,7 +12303,7 @@ func (x gen_NSImage) UnlockFocus() {
 }
 
 // Init is undocumented.
-func (x gen_NSImage) Init() NSImage {
+func (x gen_NSImage) Init_AsNSImage() NSImage {
 	ret := C.NSImage_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12585,7 +12585,7 @@ func (x gen_NSImage) SetMatchesOnlyOnBestFittingAxis(
 
 type NSImageViewRef interface {
 	Pointer() uintptr
-	Init() NSImageView
+	Init_AsNSImageView() NSImageView
 }
 
 type gen_NSImageView struct {
@@ -12603,7 +12603,7 @@ func NSImageView_FromRef(ref objc.Ref) NSImageView {
 }
 
 // Init is undocumented.
-func (x gen_NSImageView) Init() NSImageView {
+func (x gen_NSImageView) Init_AsNSImageView() NSImageView {
 	ret := C.NSImageView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12738,7 +12738,7 @@ func (x gen_NSImageView) SetContentTintColor(
 
 type NSNibRef interface {
 	Pointer() uintptr
-	Init() NSNib
+	Init_AsNSNib() NSNib
 }
 
 type gen_NSNib struct {
@@ -12788,7 +12788,7 @@ func (x gen_NSNib) InstantiateWithOwnerTopLevelObjects(
 }
 
 // Init is undocumented.
-func (x gen_NSNib) Init() NSNib {
+func (x gen_NSNib) Init_AsNSNib() NSNib {
 	ret := C.NSNib_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12798,7 +12798,7 @@ func (x gen_NSNib) Init() NSNib {
 
 type NSPasteboardRef interface {
 	Pointer() uintptr
-	Init() NSPasteboard
+	Init_AsNSPasteboard() NSPasteboard
 }
 
 type gen_NSPasteboard struct {
@@ -12944,7 +12944,7 @@ func (x gen_NSPasteboard) WriteObjects(
 }
 
 // Init is undocumented.
-func (x gen_NSPasteboard) Init() NSPasteboard {
+func (x gen_NSPasteboard) Init_AsNSPasteboard() NSPasteboard {
 	ret := C.NSPasteboard_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -12987,7 +12987,7 @@ func (x gen_NSPasteboard) ChangeCount() core.NSInteger {
 
 type NSLayoutManagerRef interface {
 	Pointer() uintptr
-	Init() NSLayoutManager
+	Init_AsNSLayoutManager() NSLayoutManager
 }
 
 type gen_NSLayoutManager struct {
@@ -13157,7 +13157,7 @@ func (x gen_NSLayoutManager) GlyphIndexForCharacterAtIndex(
 // Init initializes a newly created layout manager object.
 //
 // See https://developer.apple.com/documentation/uikit/nslayoutmanager/1402975-init?language=objc for details.
-func (x gen_NSLayoutManager) Init() NSLayoutManager {
+func (x gen_NSLayoutManager) Init_AsNSLayoutManager() NSLayoutManager {
 	ret := C.NSLayoutManager_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -13619,7 +13619,7 @@ func (x gen_NSLayoutManager) TextViewForBeginningOfSelection() NSTextView {
 
 type NSMenuRef interface {
 	Pointer() uintptr
-	Init() NSMenu
+	Init_AsNSMenu() NSMenu
 }
 
 type gen_NSMenu struct {
@@ -14009,7 +14009,7 @@ func (x gen_NSMenu) Update() {
 }
 
 // Init is undocumented.
-func (x gen_NSMenu) Init() NSMenu {
+func (x gen_NSMenu) Init_AsNSMenu() NSMenu {
 	ret := C.NSMenu_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -14288,7 +14288,7 @@ func (x gen_NSMenu) SetDelegate(
 
 type NSPopoverRef interface {
 	Pointer() uintptr
-	Init() NSPopover
+	Init_AsNSPopover() NSPopover
 }
 
 type gen_NSPopover struct {
@@ -14319,7 +14319,7 @@ func (x gen_NSPopover) Close() {
 // Init is undocumented.
 //
 // See https://developer.apple.com/documentation/appkit/nspopover/1526851-init?language=objc for details.
-func (x gen_NSPopover) Init() NSPopover {
+func (x gen_NSPopover) Init_AsNSPopover() NSPopover {
 	ret := C.NSPopover_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -14465,7 +14465,7 @@ func (x gen_NSPopover) IsDetached() bool {
 
 type NSMenuItemRef interface {
 	Pointer() uintptr
-	Init() NSMenuItem
+	Init_AsNSMenuItem() NSMenuItem
 }
 
 type gen_NSMenuItem struct {
@@ -14501,7 +14501,7 @@ func (x gen_NSMenuItem) InitWithTitleActionKeyEquivalent(
 }
 
 // Init is undocumented.
-func (x gen_NSMenuItem) Init() NSMenuItem {
+func (x gen_NSMenuItem) Init_AsNSMenuItem() NSMenuItem {
 	ret := C.NSMenuItem_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15152,7 +15152,7 @@ func (x gen_NSMenuItem) SetAllowsKeyEquivalentWhenHidden(
 
 type NSRunningApplicationRef interface {
 	Pointer() uintptr
-	Init() NSRunningApplication
+	Init_AsNSRunningApplication() NSRunningApplication
 }
 
 type gen_NSRunningApplication struct {
@@ -15214,7 +15214,7 @@ func (x gen_NSRunningApplication) Unhide() bool {
 }
 
 // Init is undocumented.
-func (x gen_NSRunningApplication) Init() NSRunningApplication {
+func (x gen_NSRunningApplication) Init_AsNSRunningApplication() NSRunningApplication {
 	ret := C.NSRunningApplication_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15356,7 +15356,7 @@ func (x gen_NSRunningApplication) IsTerminated() bool {
 
 type NSScreenRef interface {
 	Pointer() uintptr
-	Init() NSScreen
+	Init_AsNSScreen() NSScreen
 }
 
 type gen_NSScreen struct {
@@ -15402,7 +15402,7 @@ func (x gen_NSScreen) ConvertRectToBacking(
 }
 
 // Init is undocumented.
-func (x gen_NSScreen) Init() NSScreen {
+func (x gen_NSScreen) Init_AsNSScreen() NSScreen {
 	ret := C.NSScreen_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15511,7 +15511,7 @@ func (x gen_NSScreen) MaximumFramesPerSecond() core.NSInteger {
 
 type NSStatusBarRef interface {
 	Pointer() uintptr
-	Init() NSStatusBar
+	Init_AsNSStatusBar() NSStatusBar
 }
 
 type gen_NSStatusBar struct {
@@ -15557,7 +15557,7 @@ func (x gen_NSStatusBar) StatusItemWithLength(
 }
 
 // Init is undocumented.
-func (x gen_NSStatusBar) Init() NSStatusBar {
+func (x gen_NSStatusBar) Init_AsNSStatusBar() NSStatusBar {
 	ret := C.NSStatusBar_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15589,7 +15589,7 @@ func (x gen_NSStatusBar) Thickness() core.CGFloat {
 
 type NSStatusBarButtonRef interface {
 	Pointer() uintptr
-	Init() NSStatusBarButton
+	Init_AsNSStatusBarButton() NSStatusBarButton
 }
 
 type gen_NSStatusBarButton struct {
@@ -15607,7 +15607,7 @@ func NSStatusBarButton_FromRef(ref objc.Ref) NSStatusBarButton {
 }
 
 // Init is undocumented.
-func (x gen_NSStatusBarButton) Init() NSStatusBarButton {
+func (x gen_NSStatusBarButton) Init_AsNSStatusBarButton() NSStatusBarButton {
 	ret := C.NSStatusBarButton_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15642,7 +15642,7 @@ func (x gen_NSStatusBarButton) SetAppearsDisabled(
 
 type NSStatusItemRef interface {
 	Pointer() uintptr
-	Init() NSStatusItem
+	Init_AsNSStatusItem() NSStatusItem
 }
 
 type gen_NSStatusItem struct {
@@ -15660,7 +15660,7 @@ func NSStatusItem_FromRef(ref objc.Ref) NSStatusItem {
 }
 
 // Init is undocumented.
-func (x gen_NSStatusItem) Init() NSStatusItem {
+func (x gen_NSStatusItem) Init_AsNSStatusItem() NSStatusItem {
 	ret := C.NSStatusItem_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -15767,7 +15767,7 @@ func (x gen_NSStatusItem) SetLength(
 
 type NSTextRef interface {
 	Pointer() uintptr
-	Init() NSText
+	Init_AsNSText() NSText
 }
 
 type gen_NSText struct {
@@ -16120,7 +16120,7 @@ func (x gen_NSText) WriteRTFDToFileAtomically(
 }
 
 // Init is undocumented.
-func (x gen_NSText) Init() NSText {
+func (x gen_NSText) Init_AsNSText() NSText {
 	ret := C.NSText_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -16541,7 +16541,7 @@ func (x gen_NSText) SetDelegate(
 
 type NSTextFieldRef interface {
 	Pointer() uintptr
-	Init() NSTextField
+	Init_AsNSTextField() NSTextField
 }
 
 type gen_NSTextField struct {
@@ -16601,7 +16601,7 @@ func (x gen_NSTextField) TextShouldEndEditing(
 }
 
 // Init is undocumented.
-func (x gen_NSTextField) Init() NSTextField {
+func (x gen_NSTextField) Init_AsNSTextField() NSTextField {
 	ret := C.NSTextField_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17047,7 +17047,7 @@ func (x gen_NSTextField) SetDelegate(
 
 type NSTextContainerRef interface {
 	Pointer() uintptr
-	Init() NSTextContainer
+	Init_AsNSTextContainer() NSTextContainer
 }
 
 type gen_NSTextContainer struct {
@@ -17093,7 +17093,7 @@ func (x gen_NSTextContainer) ReplaceLayoutManager(
 }
 
 // Init is undocumented.
-func (x gen_NSTextContainer) Init() NSTextContainer {
+func (x gen_NSTextContainer) Init_AsNSTextContainer() NSTextContainer {
 	ret := C.NSTextContainer_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17314,7 +17314,7 @@ func (x gen_NSTextContainer) IsSimpleRectangularTextContainer() bool {
 
 type NSViewControllerRef interface {
 	Pointer() uintptr
-	Init() NSViewController
+	Init_AsNSViewController() NSViewController
 }
 
 type gen_NSViewController struct {
@@ -17626,7 +17626,7 @@ func (x gen_NSViewController) ViewWillTransitionToSize(
 }
 
 // Init is undocumented.
-func (x gen_NSViewController) Init() NSViewController {
+func (x gen_NSViewController) Init_AsNSViewController() NSViewController {
 	ret := C.NSViewController_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17888,7 +17888,7 @@ func (x gen_NSViewController) SetSourceItemView(
 
 type NSVisualEffectViewRef interface {
 	Pointer() uintptr
-	Init() NSVisualEffectView
+	Init_AsNSVisualEffectView() NSVisualEffectView
 }
 
 type gen_NSVisualEffectView struct {
@@ -17931,7 +17931,7 @@ func (x gen_NSVisualEffectView) ViewWillMoveToWindow(
 }
 
 // Init is undocumented.
-func (x gen_NSVisualEffectView) Init() NSVisualEffectView {
+func (x gen_NSVisualEffectView) Init_AsNSVisualEffectView() NSVisualEffectView {
 	ret := C.NSVisualEffectView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -17991,7 +17991,7 @@ func (x gen_NSVisualEffectView) SetMaskImage(
 
 type NSWindowRef interface {
 	Pointer() uintptr
-	Init() NSWindow
+	Init_AsNSWindow() NSWindow
 }
 
 type gen_NSWindow struct {
@@ -19265,7 +19265,7 @@ func (x gen_NSWindow) Zoom(
 }
 
 // Init is undocumented.
-func (x gen_NSWindow) Init() NSWindow {
+func (x gen_NSWindow) Init_AsNSWindow() NSWindow {
 	ret := C.NSWindow_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -20960,7 +20960,7 @@ func (x gen_NSWindow) SetOrderedIndex(
 
 type NSWorkspaceRef interface {
 	Pointer() uintptr
-	Init() NSWorkspace
+	Init_AsNSWorkspace() NSWorkspace
 }
 
 type gen_NSWorkspace struct {
@@ -21215,7 +21215,7 @@ func (x gen_NSWorkspace) UnmountAndEjectDeviceAtPath(
 }
 
 // Init is undocumented.
-func (x gen_NSWorkspace) Init() NSWorkspace {
+func (x gen_NSWorkspace) Init_AsNSWorkspace() NSWorkspace {
 	ret := C.NSWorkspace_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -21357,7 +21357,7 @@ func (x gen_NSWorkspace) IsVoiceOverEnabled() bool {
 
 type NSColorRef interface {
 	Pointer() uintptr
-	Init() NSColor
+	Init_AsNSColor() NSColor
 }
 
 type gen_NSColor struct {
@@ -21494,7 +21494,7 @@ func (x gen_NSColor) WriteToPasteboard(
 }
 
 // Init is undocumented.
-func (x gen_NSColor) Init() NSColor {
+func (x gen_NSColor) Init_AsNSColor() NSColor {
 	ret := C.NSColor_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -21669,7 +21669,7 @@ func (x gen_NSColor) LocalizedColorNameComponent() core.NSString {
 
 type NSTextViewRef interface {
 	Pointer() uintptr
-	Init() NSTextView
+	Init_AsNSTextView() NSTextView
 }
 
 type gen_NSTextView struct {
@@ -22596,7 +22596,7 @@ func (x gen_NSTextView) WriteSelectionToPasteboardTypes(
 }
 
 // Init is undocumented.
-func (x gen_NSTextView) Init() NSTextView {
+func (x gen_NSTextView) Init_AsNSTextView() NSTextView {
 	ret := C.NSTextView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -23798,7 +23798,7 @@ func (x gen_NSTextView) SetFont(
 
 type NSViewRef interface {
 	Pointer() uintptr
-	Init() NSView
+	Init_AsNSView() NSView
 }
 
 type gen_NSView struct {
@@ -25323,7 +25323,7 @@ func (x gen_NSView) WritePDFInsideRectToPasteboard(
 }
 
 // Init is undocumented.
-func (x gen_NSView) Init() NSView {
+func (x gen_NSView) Init_AsNSView() NSView {
 	ret := C.NSView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)

--- a/core/NSAttributedString.go
+++ b/core/NSAttributedString.go
@@ -14,7 +14,7 @@ type NSAttributedString struct {
 // https://developer.apple.com/documentation/foundation/nsattributedstring/1407481-initwithstring?language=objc
 func NSAttributedString_FromString(str string) NSAttributedString {
 	nsstr := NSString_FromString(str)
-	return NSAttributedString_Alloc().InitWithString_AsNSAttributedString(nsstr)
+	return NSAttributedString_Alloc().InitWithString(nsstr)
 }
 
 func NSAttributedString_FromObject(obj objc.Object) NSAttributedString {

--- a/core/NSDictionary.go
+++ b/core/NSDictionary.go
@@ -9,7 +9,7 @@ type NSDictionary struct {
 }
 
 func NSDictionary_New() NSDictionary {
-	return NSDictionary_Alloc().Init_AsNSDictionary()
+	return NSDictionary_Alloc().Init()
 }
 
 func NSDictionary_Init(valueKeys ...interface{}) NSDictionary {

--- a/core/NSString.go
+++ b/core/NSString.go
@@ -30,7 +30,7 @@ func NSString_FromString(s string) NSString {
 	b := []byte(s)
 	c := C.CBytes(b)
 	defer C.free(unsafe.Pointer(c))
-	ret := NSString_Alloc().InitWithBytesLengthEncoding_AsNSString(c, NSUInteger(len(b)), NSUTF8StringEncoding)
+	ret := NSString_Alloc().InitWithBytesLengthEncoding(c, NSUInteger(len(b)), NSUTF8StringEncoding)
 	return ret
 }
 

--- a/core/callback.go
+++ b/core/callback.go
@@ -28,7 +28,7 @@ func Callback(fn interface{}) (objc.Object, objc.Selector) {
 	cb := callbackEntry{
 		cb:       fn,
 		class:    c,
-		instance: objc.Get(delegateName).Alloc().Init(),
+		instance: objc.Get(delegateName).Alloc().InitObject(),
 	}
 	//fmt.Fprintf(os.Stderr, "%#v %d\n", delegateName, &fn)
 	//callbacks.Store(rfn.Type().String(), cb)

--- a/core/core_objc.gen.go
+++ b/core/core_objc.gen.go
@@ -2955,6 +2955,17 @@ func (x gen_CALayer) Init() CALayer {
 	return CALayer_FromPointer(ret)
 }
 
+// Init_AsCALayer is a typed version of Init.
+//
+// See https://developer.apple.com/documentation/quartzcore/calayer/1410835-init?language=objc for details.
+func (x gen_CALayer) Init_AsCALayer() CALayer {
+	ret := C.CALayer_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return CALayer_FromPointer(ret)
+}
+
 // InitWithLayer override to copy or initialize custom fields of the specified layer.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410842-initwithlayer?language=objc for details.
@@ -4198,6 +4209,17 @@ func (x gen_NSArray) Init() NSArray {
 	return NSArray_FromPointer(ret)
 }
 
+// Init_AsNSArray is a typed version of Init.
+//
+// See https://developer.apple.com/documentation/foundation/nsarray/1414315-init?language=objc for details.
+func (x gen_NSArray) Init_AsNSArray() NSArray {
+	ret := C.NSArray_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSArray_FromPointer(ret)
+}
+
 // InitWithArray initializes a newly allocated array by placing in it the objects contained in a given array.
 //
 // See https://developer.apple.com/documentation/foundation/nsarray/1412169-initwitharray?language=objc for details.
@@ -4617,8 +4639,17 @@ func (x gen_NSAttributedString) Size() NSSize {
 	return *(*NSSize)(unsafe.Pointer(&ret))
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSAttributedString class.
 func (x gen_NSAttributedString) Init() NSAttributedString {
+	ret := C.NSAttributedString_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSAttributedString_FromPointer(ret)
+}
+
+// Init_AsNSAttributedString is a typed version of Init.
+func (x gen_NSAttributedString) Init_AsNSAttributedString() NSAttributedString {
 	ret := C.NSAttributedString_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4821,8 +4852,17 @@ func (x gen_NSData) WriteToURLAtomically(
 	return convertObjCBoolToGo(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSData class.
 func (x gen_NSData) Init() NSData {
+	ret := C.NSData_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSData_FromPointer(ret)
+}
+
+// Init_AsNSData is a typed version of Init.
+func (x gen_NSData) Init_AsNSData() NSData {
 	ret := C.NSData_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5037,6 +5077,17 @@ func (x gen_NSDictionary) FileType() NSString {
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1418147-init?language=objc for details.
 func (x gen_NSDictionary) Init() NSDictionary {
+	ret := C.NSDictionary_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSDictionary_FromPointer(ret)
+}
+
+// Init_AsNSDictionary is a typed version of Init.
+//
+// See https://developer.apple.com/documentation/foundation/nsdictionary/1418147-init?language=objc for details.
+func (x gen_NSDictionary) Init_AsNSDictionary() NSDictionary {
 	ret := C.NSDictionary_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5290,8 +5341,17 @@ func (x gen_NSNumber) IsEqualToNumber(
 	return convertObjCBoolToGo(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSNumber class.
 func (x gen_NSNumber) Init() NSNumber {
+	ret := C.NSNumber_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSNumber_FromPointer(ret)
+}
+
+// Init_AsNSNumber is a typed version of Init.
+func (x gen_NSNumber) Init_AsNSNumber() NSNumber {
 	ret := C.NSNumber_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5449,8 +5509,17 @@ func (x gen_NSRunLoop) Run() {
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSRunLoop class.
 func (x gen_NSRunLoop) Init() NSRunLoop {
+	ret := C.NSRunLoop_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSRunLoop_FromPointer(ret)
+}
+
+// Init_AsNSRunLoop is a typed version of Init.
+func (x gen_NSRunLoop) Init_AsNSRunLoop() NSRunLoop {
 	ret := C.NSRunLoop_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5631,6 +5700,17 @@ func (x gen_NSString) HasSuffix(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1409306-init?language=objc for details.
 func (x gen_NSString) Init() NSString {
+	ret := C.NSString_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSString_FromPointer(ret)
+}
+
+// Init_AsNSString is a typed version of Init.
+//
+// See https://developer.apple.com/documentation/foundation/nsstring/1409306-init?language=objc for details.
+func (x gen_NSString) Init_AsNSString() NSString {
 	ret := C.NSString_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -6304,6 +6384,17 @@ func (x gen_NSThread) Init() NSThread {
 	return NSThread_FromPointer(ret)
 }
 
+// Init_AsNSThread is a typed version of Init.
+//
+// See https://developer.apple.com/documentation/foundation/nsthread/1416464-init?language=objc for details.
+func (x gen_NSThread) Init_AsNSThread() NSThread {
+	ret := C.NSThread_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSThread_FromPointer(ret)
+}
+
 // InitWithTargetSelectorObject returns an NSThread object initialized with the given arguments.
 //
 // See https://developer.apple.com/documentation/foundation/nsthread/1414773-initwithtarget?language=objc for details.
@@ -6682,8 +6773,17 @@ func (x gen_NSURL) StopAccessingSecurityScopedResource() {
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSURL class.
 func (x gen_NSURL) Init() NSURL {
+	ret := C.NSURL_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSURL_FromPointer(ret)
+}
+
+// Init_AsNSURL is a typed version of Init.
+func (x gen_NSURL) Init_AsNSURL() NSURL {
 	ret := C.NSURL_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -7024,8 +7124,17 @@ func (x gen_NSURLRequest) ValueForHTTPHeaderField(
 	return NSString_FromPointer(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the NSURLRequest class.
 func (x gen_NSURLRequest) Init() NSURLRequest {
+	ret := C.NSURLRequest_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSURLRequest_FromPointer(ret)
+}
+
+// Init_AsNSURLRequest is a typed version of Init.
+func (x gen_NSURLRequest) Init_AsNSURLRequest() NSURLRequest {
 	ret := C.NSURLRequest_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -7272,6 +7381,17 @@ func (x gen_NSUserDefaults) DictionaryRepresentation() NSDictionary {
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1414356-init?language=objc for details.
 func (x gen_NSUserDefaults) Init() NSUserDefaults {
+	ret := C.NSUserDefaults_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return NSUserDefaults_FromPointer(ret)
+}
+
+// Init_AsNSUserDefaults is a typed version of Init.
+//
+// See https://developer.apple.com/documentation/foundation/nsuserdefaults/1414356-init?language=objc for details.
+func (x gen_NSUserDefaults) Init_AsNSUserDefaults() NSUserDefaults {
 	ret := C.NSUserDefaults_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)

--- a/core/core_objc.gen.go
+++ b/core/core_objc.gen.go
@@ -2823,7 +2823,7 @@ func NSUserDefaults_StandardUserDefaults() NSUserDefaults {
 
 type CALayerRef interface {
 	Pointer() uintptr
-	Init_AsCALayer() CALayer
+	Init() CALayer
 }
 
 type gen_CALayer struct {
@@ -2947,7 +2947,7 @@ func (x gen_CALayer) DisplayIfNeeded() {
 // Init returns an initialized CALayer object.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410835-init?language=objc for details.
-func (x gen_CALayer) Init_AsCALayer() CALayer {
+func (x gen_CALayer) Init() CALayer {
 	ret := C.CALayer_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -2958,7 +2958,7 @@ func (x gen_CALayer) Init_AsCALayer() CALayer {
 // InitWithLayer override to copy or initialize custom fields of the specified layer.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410842-initwithlayer?language=objc for details.
-func (x gen_CALayer) InitWithLayer_AsCALayer(
+func (x gen_CALayer) InitWithLayer(
 	layer objc.Ref,
 ) CALayer {
 	ret := C.CALayer_inst_InitWithLayer(
@@ -3042,7 +3042,7 @@ func (x gen_CALayer) LayoutSublayers() {
 // ModelLayer returns the model layer object associated with the receiver, if any.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410853-modellayer?language=objc for details.
-func (x gen_CALayer) ModelLayer_AsCALayer() CALayer {
+func (x gen_CALayer) ModelLayer() CALayer {
 	ret := C.CALayer_inst_ModelLayer(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -3086,7 +3086,7 @@ func (x gen_CALayer) PreferredFrameSize() NSSize {
 // PresentationLayer returns a copy of the presentation layer object that represents the state of the layer as it currently appears onscreen.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410744-presentationlayer?language=objc for details.
-func (x gen_CALayer) PresentationLayer_AsCALayer() CALayer {
+func (x gen_CALayer) PresentationLayer() CALayer {
 	ret := C.CALayer_inst_PresentationLayer(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4112,7 +4112,7 @@ func (x gen_CALayer) SetName(
 
 type NSArrayRef interface {
 	Pointer() uintptr
-	Init_AsNSArray() NSArray
+	Init() NSArray
 }
 
 type gen_NSArray struct {
@@ -4190,7 +4190,7 @@ func (x gen_NSArray) DescriptionWithLocaleIndent(
 // Init initializes a newly allocated array.
 //
 // See https://developer.apple.com/documentation/foundation/nsarray/1414315-init?language=objc for details.
-func (x gen_NSArray) Init_AsNSArray() NSArray {
+func (x gen_NSArray) Init() NSArray {
 	ret := C.NSArray_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4201,7 +4201,7 @@ func (x gen_NSArray) Init_AsNSArray() NSArray {
 // InitWithArray initializes a newly allocated array by placing in it the objects contained in a given array.
 //
 // See https://developer.apple.com/documentation/foundation/nsarray/1412169-initwitharray?language=objc for details.
-func (x gen_NSArray) InitWithArray_AsNSArray(
+func (x gen_NSArray) InitWithArray(
 	array NSArrayRef,
 ) NSArray {
 	ret := C.NSArray_inst_InitWithArray(
@@ -4215,7 +4215,7 @@ func (x gen_NSArray) InitWithArray_AsNSArray(
 // InitWithArrayCopyItems initializes a newly allocated array using anArray as the source of data objects for the array.
 //
 // See https://developer.apple.com/documentation/foundation/nsarray/1408557-initwitharray?language=objc for details.
-func (x gen_NSArray) InitWithArrayCopyItems_AsNSArray(
+func (x gen_NSArray) InitWithArrayCopyItems(
 	array NSArrayRef,
 	flag bool,
 ) NSArray {
@@ -4390,7 +4390,7 @@ func (x gen_NSArray) Description() NSString {
 
 type NSAttributedStringRef interface {
 	Pointer() uintptr
-	Init_AsNSAttributedString() NSAttributedString
+	Init() NSAttributedString
 }
 
 type gen_NSAttributedString struct {
@@ -4435,7 +4435,7 @@ func (x gen_NSAttributedString) DrawInRect(
 // InitWithAttributedString creates an attributed string with the characters and attributes of the specified attributed string.
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1415342-initwithattributedstring?language=objc for details.
-func (x gen_NSAttributedString) InitWithAttributedString_AsNSAttributedString(
+func (x gen_NSAttributedString) InitWithAttributedString(
 	attrStr NSAttributedStringRef,
 ) NSAttributedString {
 	ret := C.NSAttributedString_inst_InitWithAttributedString(
@@ -4449,7 +4449,7 @@ func (x gen_NSAttributedString) InitWithAttributedString_AsNSAttributedString(
 // InitWithDocFormatDocumentAttributes creates an attributed string from Microsoft Word format data in the specified data object.
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1534329-initwithdocformat?language=objc for details.
-func (x gen_NSAttributedString) InitWithDocFormatDocumentAttributes_AsNSAttributedString(
+func (x gen_NSAttributedString) InitWithDocFormatDocumentAttributes(
 	data NSDataRef,
 	dict NSDictionaryRef,
 ) NSAttributedString {
@@ -4465,7 +4465,7 @@ func (x gen_NSAttributedString) InitWithDocFormatDocumentAttributes_AsNSAttribut
 // InitWithHTMLBaseURLDocumentAttributes creates an attributed string from the HTML in the specified data object and base URL.
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1524624-initwithhtml?language=objc for details.
-func (x gen_NSAttributedString) InitWithHTMLBaseURLDocumentAttributes_AsNSAttributedString(
+func (x gen_NSAttributedString) InitWithHTMLBaseURLDocumentAttributes(
 	data NSDataRef,
 	base NSURLRef,
 	dict NSDictionaryRef,
@@ -4483,7 +4483,7 @@ func (x gen_NSAttributedString) InitWithHTMLBaseURLDocumentAttributes_AsNSAttrib
 // InitWithHTMLDocumentAttributes creates an attributed string from the HTML in the specified data object.
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1525953-initwithhtml?language=objc for details.
-func (x gen_NSAttributedString) InitWithHTMLDocumentAttributes_AsNSAttributedString(
+func (x gen_NSAttributedString) InitWithHTMLDocumentAttributes(
 	data NSDataRef,
 	dict NSDictionaryRef,
 ) NSAttributedString {
@@ -4499,7 +4499,7 @@ func (x gen_NSAttributedString) InitWithHTMLDocumentAttributes_AsNSAttributedStr
 // InitWithHTMLOptionsDocumentAttributes creates an attributed string from the HTML in the specified data object.
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1535412-initwithhtml?language=objc for details.
-func (x gen_NSAttributedString) InitWithHTMLOptionsDocumentAttributes_AsNSAttributedString(
+func (x gen_NSAttributedString) InitWithHTMLOptionsDocumentAttributes(
 	data NSDataRef,
 	options NSDictionaryRef,
 	dict NSDictionaryRef,
@@ -4517,7 +4517,7 @@ func (x gen_NSAttributedString) InitWithHTMLOptionsDocumentAttributes_AsNSAttrib
 // InitWithRTFDocumentAttributes creates an attributed string by decoding the stream of RTF commands and data in the specified data object.
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1532912-initwithrtf?language=objc for details.
-func (x gen_NSAttributedString) InitWithRTFDocumentAttributes_AsNSAttributedString(
+func (x gen_NSAttributedString) InitWithRTFDocumentAttributes(
 	data NSDataRef,
 	dict NSDictionaryRef,
 ) NSAttributedString {
@@ -4533,7 +4533,7 @@ func (x gen_NSAttributedString) InitWithRTFDocumentAttributes_AsNSAttributedStri
 // InitWithRTFDDocumentAttributes creates an attributed string by decoding the stream of RTFD commands and data in the specified data object.
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1530987-initwithrtfd?language=objc for details.
-func (x gen_NSAttributedString) InitWithRTFDDocumentAttributes_AsNSAttributedString(
+func (x gen_NSAttributedString) InitWithRTFDDocumentAttributes(
 	data NSDataRef,
 	dict NSDictionaryRef,
 ) NSAttributedString {
@@ -4549,7 +4549,7 @@ func (x gen_NSAttributedString) InitWithRTFDDocumentAttributes_AsNSAttributedStr
 // InitWithString creates an attributed string with the characters of the specified string and no attribute information.
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1407481-initwithstring?language=objc for details.
-func (x gen_NSAttributedString) InitWithString_AsNSAttributedString(
+func (x gen_NSAttributedString) InitWithString(
 	str NSStringRef,
 ) NSAttributedString {
 	ret := C.NSAttributedString_inst_InitWithString(
@@ -4563,7 +4563,7 @@ func (x gen_NSAttributedString) InitWithString_AsNSAttributedString(
 // InitWithStringAttributes creates an attributed string with the specified string and attributes.
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1408136-initwithstring?language=objc for details.
-func (x gen_NSAttributedString) InitWithStringAttributes_AsNSAttributedString(
+func (x gen_NSAttributedString) InitWithStringAttributes(
 	str NSStringRef,
 	attrs NSDictionaryRef,
 ) NSAttributedString {
@@ -4618,7 +4618,7 @@ func (x gen_NSAttributedString) Size() NSSize {
 }
 
 // Init is undocumented.
-func (x gen_NSAttributedString) Init_AsNSAttributedString() NSAttributedString {
+func (x gen_NSAttributedString) Init() NSAttributedString {
 	ret := C.NSAttributedString_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4650,7 +4650,7 @@ func (x gen_NSAttributedString) Length() NSUInteger {
 
 type NSDataRef interface {
 	Pointer() uintptr
-	Init_AsNSData() NSData
+	Init() NSData
 }
 
 type gen_NSData struct {
@@ -4686,7 +4686,7 @@ func (x gen_NSData) GetBytesLength(
 // InitWithBytesLength initializes a data object filled with a given number of bytes copied from a given buffer.
 //
 // See https://developer.apple.com/documentation/foundation/nsdata/1412793-initwithbytes?language=objc for details.
-func (x gen_NSData) InitWithBytesLength_AsNSData(
+func (x gen_NSData) InitWithBytesLength(
 	bytes unsafe.Pointer,
 	length NSUInteger,
 ) NSData {
@@ -4702,7 +4702,7 @@ func (x gen_NSData) InitWithBytesLength_AsNSData(
 // InitWithBytesNoCopyLength initializes a data object filled with a given number of bytes of data from a given buffer.
 //
 // See https://developer.apple.com/documentation/foundation/nsdata/1409454-initwithbytesnocopy?language=objc for details.
-func (x gen_NSData) InitWithBytesNoCopyLength_AsNSData(
+func (x gen_NSData) InitWithBytesNoCopyLength(
 	bytes unsafe.Pointer,
 	length NSUInteger,
 ) NSData {
@@ -4718,7 +4718,7 @@ func (x gen_NSData) InitWithBytesNoCopyLength_AsNSData(
 // InitWithBytesNoCopyLengthFreeWhenDone initializes a newly allocated data object by adding the given number of bytes from the given buffer.
 //
 // See https://developer.apple.com/documentation/foundation/nsdata/1416020-initwithbytesnocopy?language=objc for details.
-func (x gen_NSData) InitWithBytesNoCopyLengthFreeWhenDone_AsNSData(
+func (x gen_NSData) InitWithBytesNoCopyLengthFreeWhenDone(
 	bytes unsafe.Pointer,
 	length NSUInteger,
 	b bool,
@@ -4736,7 +4736,7 @@ func (x gen_NSData) InitWithBytesNoCopyLengthFreeWhenDone_AsNSData(
 // InitWithContentsOfFile initializes a data object with the content of the file at a given path.
 //
 // See https://developer.apple.com/documentation/foundation/nsdata/1408672-initwithcontentsoffile?language=objc for details.
-func (x gen_NSData) InitWithContentsOfFile_AsNSData(
+func (x gen_NSData) InitWithContentsOfFile(
 	path NSStringRef,
 ) NSData {
 	ret := C.NSData_inst_InitWithContentsOfFile(
@@ -4750,7 +4750,7 @@ func (x gen_NSData) InitWithContentsOfFile_AsNSData(
 // InitWithContentsOfURL initializes a data object with the data from the location specified by a given URL.
 //
 // See https://developer.apple.com/documentation/foundation/nsdata/1413892-initwithcontentsofurl?language=objc for details.
-func (x gen_NSData) InitWithContentsOfURL_AsNSData(
+func (x gen_NSData) InitWithContentsOfURL(
 	url NSURLRef,
 ) NSData {
 	ret := C.NSData_inst_InitWithContentsOfURL(
@@ -4764,7 +4764,7 @@ func (x gen_NSData) InitWithContentsOfURL_AsNSData(
 // InitWithData initializes a data object with the contents of another data object.
 //
 // See https://developer.apple.com/documentation/foundation/nsdata/1417055-initwithdata?language=objc for details.
-func (x gen_NSData) InitWithData_AsNSData(
+func (x gen_NSData) InitWithData(
 	data NSDataRef,
 ) NSData {
 	ret := C.NSData_inst_InitWithData(
@@ -4822,7 +4822,7 @@ func (x gen_NSData) WriteToURLAtomically(
 }
 
 // Init is undocumented.
-func (x gen_NSData) Init_AsNSData() NSData {
+func (x gen_NSData) Init() NSData {
 	ret := C.NSData_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4865,7 +4865,7 @@ func (x gen_NSData) Description() NSString {
 
 type NSDictionaryRef interface {
 	Pointer() uintptr
-	Init_AsNSDictionary() NSDictionary
+	Init() NSDictionary
 }
 
 type gen_NSDictionary struct {
@@ -5036,7 +5036,7 @@ func (x gen_NSDictionary) FileType() NSString {
 // Init initializes a newly allocated dictionary.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1418147-init?language=objc for details.
-func (x gen_NSDictionary) Init_AsNSDictionary() NSDictionary {
+func (x gen_NSDictionary) Init() NSDictionary {
 	ret := C.NSDictionary_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5047,7 +5047,7 @@ func (x gen_NSDictionary) Init_AsNSDictionary() NSDictionary {
 // InitWithDictionary initializes a newly allocated dictionary by placing in it the keys and values contained in another given dictionary.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1418434-initwithdictionary?language=objc for details.
-func (x gen_NSDictionary) InitWithDictionary_AsNSDictionary(
+func (x gen_NSDictionary) InitWithDictionary(
 	otherDictionary NSDictionaryRef,
 ) NSDictionary {
 	ret := C.NSDictionary_inst_InitWithDictionary(
@@ -5061,7 +5061,7 @@ func (x gen_NSDictionary) InitWithDictionary_AsNSDictionary(
 // InitWithDictionaryCopyItems initializes a newly allocated dictionary using the objects contained in another given dictionary.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1410124-initwithdictionary?language=objc for details.
-func (x gen_NSDictionary) InitWithDictionaryCopyItems_AsNSDictionary(
+func (x gen_NSDictionary) InitWithDictionaryCopyItems(
 	otherDictionary NSDictionaryRef,
 	flag bool,
 ) NSDictionary {
@@ -5077,7 +5077,7 @@ func (x gen_NSDictionary) InitWithDictionaryCopyItems_AsNSDictionary(
 // InitWithObjectsForKeys initializes a newly allocated dictionary with key-value pairs constructed from the provided arrays of keys and objects.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1410010-initwithobjects?language=objc for details.
-func (x gen_NSDictionary) InitWithObjectsForKeys_AsNSDictionary(
+func (x gen_NSDictionary) InitWithObjectsForKeys(
 	objects NSArrayRef,
 	keys NSArrayRef,
 ) NSDictionary {
@@ -5175,7 +5175,7 @@ func (x gen_NSDictionary) DescriptionInStringsFileFormat() NSString {
 
 type NSNumberRef interface {
 	Pointer() uintptr
-	Init_AsNSNumber() NSNumber
+	Init() NSNumber
 }
 
 type gen_NSNumber struct {
@@ -5291,7 +5291,7 @@ func (x gen_NSNumber) IsEqualToNumber(
 }
 
 // Init is undocumented.
-func (x gen_NSNumber) Init_AsNSNumber() NSNumber {
+func (x gen_NSNumber) Init() NSNumber {
 	ret := C.NSNumber_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5367,7 +5367,7 @@ func (x gen_NSNumber) StringValue() NSString {
 
 type NSRunLoopRef interface {
 	Pointer() uintptr
-	Init_AsNSRunLoop() NSRunLoop
+	Init() NSRunLoop
 }
 
 type gen_NSRunLoop struct {
@@ -5450,7 +5450,7 @@ func (x gen_NSRunLoop) Run() {
 }
 
 // Init is undocumented.
-func (x gen_NSRunLoop) Init_AsNSRunLoop() NSRunLoop {
+func (x gen_NSRunLoop) Init() NSRunLoop {
 	ret := C.NSRunLoop_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5460,7 +5460,7 @@ func (x gen_NSRunLoop) Init_AsNSRunLoop() NSRunLoop {
 
 type NSStringRef interface {
 	Pointer() uintptr
-	Init_AsNSString() NSString
+	Init() NSString
 }
 
 type gen_NSString struct {
@@ -5630,7 +5630,7 @@ func (x gen_NSString) HasSuffix(
 // Init returns an initialized NSString object that contains no characters.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1409306-init?language=objc for details.
-func (x gen_NSString) Init_AsNSString() NSString {
+func (x gen_NSString) Init() NSString {
 	ret := C.NSString_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5641,7 +5641,7 @@ func (x gen_NSString) Init_AsNSString() NSString {
 // InitWithBytesLengthEncoding returns an initialized NSString object containing a given number of bytes from a given buffer of bytes interpreted in a given encoding.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1407339-initwithbytes?language=objc for details.
-func (x gen_NSString) InitWithBytesLengthEncoding_AsNSString(
+func (x gen_NSString) InitWithBytesLengthEncoding(
 	bytes unsafe.Pointer,
 	len NSUInteger,
 	encoding NSStringEncoding,
@@ -5659,7 +5659,7 @@ func (x gen_NSString) InitWithBytesLengthEncoding_AsNSString(
 // InitWithBytesNoCopyLengthEncodingFreeWhenDone returns an initialized NSString object that contains a given number of bytes from a given buffer of bytes interpreted in a given encoding, and optionally frees the buffer.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1413830-initwithbytesnocopy?language=objc for details.
-func (x gen_NSString) InitWithBytesNoCopyLengthEncodingFreeWhenDone_AsNSString(
+func (x gen_NSString) InitWithBytesNoCopyLengthEncodingFreeWhenDone(
 	bytes unsafe.Pointer,
 	len NSUInteger,
 	encoding NSStringEncoding,
@@ -5679,7 +5679,7 @@ func (x gen_NSString) InitWithBytesNoCopyLengthEncodingFreeWhenDone_AsNSString(
 // InitWithDataEncoding returns an NSString object initialized by converting given data into UTF-16 code units using a given encoding.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1416374-initwithdata?language=objc for details.
-func (x gen_NSString) InitWithDataEncoding_AsNSString(
+func (x gen_NSString) InitWithDataEncoding(
 	data NSDataRef,
 	encoding NSStringEncoding,
 ) NSString {
@@ -5695,7 +5695,7 @@ func (x gen_NSString) InitWithDataEncoding_AsNSString(
 // InitWithString returns an NSString object initialized by copying the characters from another given string.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1411293-initwithstring?language=objc for details.
-func (x gen_NSString) InitWithString_AsNSString(
+func (x gen_NSString) InitWithString(
 	aString NSStringRef,
 ) NSString {
 	ret := C.NSString_inst_InitWithString(
@@ -6265,7 +6265,7 @@ func (x gen_NSString) StringByRemovingPercentEncoding() NSString {
 
 type NSThreadRef interface {
 	Pointer() uintptr
-	Init_AsNSThread() NSThread
+	Init() NSThread
 }
 
 type gen_NSThread struct {
@@ -6296,7 +6296,7 @@ func (x gen_NSThread) Cancel() {
 // Init returns an initialized NSThread object.
 //
 // See https://developer.apple.com/documentation/foundation/nsthread/1416464-init?language=objc for details.
-func (x gen_NSThread) Init_AsNSThread() NSThread {
+func (x gen_NSThread) Init() NSThread {
 	ret := C.NSThread_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -6307,7 +6307,7 @@ func (x gen_NSThread) Init_AsNSThread() NSThread {
 // InitWithTargetSelectorObject returns an NSThread object initialized with the given arguments.
 //
 // See https://developer.apple.com/documentation/foundation/nsthread/1414773-initwithtarget?language=objc for details.
-func (x gen_NSThread) InitWithTargetSelectorObject_AsNSThread(
+func (x gen_NSThread) InitWithTargetSelectorObject(
 	target objc.Ref,
 	selector objc.Selector,
 	argument objc.Ref,
@@ -6440,7 +6440,7 @@ func (x gen_NSThread) SetStackSize(
 
 type NSURLRef interface {
 	Pointer() uintptr
-	Init_AsNSURL() NSURL
+	Init() NSURL
 }
 
 type gen_NSURL struct {
@@ -6515,7 +6515,7 @@ func (x gen_NSURL) FileReferenceURL() NSURL {
 // InitAbsoluteURLWithDataRepresentationRelativeToURL is undocumented.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1410750-initabsoluteurlwithdatarepresent?language=objc for details.
-func (x gen_NSURL) InitAbsoluteURLWithDataRepresentationRelativeToURL_AsNSURL(
+func (x gen_NSURL) InitAbsoluteURLWithDataRepresentationRelativeToURL(
 	data NSDataRef,
 	baseURL NSURLRef,
 ) NSURL {
@@ -6531,7 +6531,7 @@ func (x gen_NSURL) InitAbsoluteURLWithDataRepresentationRelativeToURL_AsNSURL(
 // InitFileURLWithPath initializes a newly created NSURL referencing the local file or directory at path.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1410301-initfileurlwithpath?language=objc for details.
-func (x gen_NSURL) InitFileURLWithPath_AsNSURL(
+func (x gen_NSURL) InitFileURLWithPath(
 	path NSStringRef,
 ) NSURL {
 	ret := C.NSURL_inst_InitFileURLWithPath(
@@ -6545,7 +6545,7 @@ func (x gen_NSURL) InitFileURLWithPath_AsNSURL(
 // InitFileURLWithPathIsDirectory initializes a newly created NSURL referencing the local file or directory at path.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1417505-initfileurlwithpath?language=objc for details.
-func (x gen_NSURL) InitFileURLWithPathIsDirectory_AsNSURL(
+func (x gen_NSURL) InitFileURLWithPathIsDirectory(
 	path NSStringRef,
 	isDir bool,
 ) NSURL {
@@ -6561,7 +6561,7 @@ func (x gen_NSURL) InitFileURLWithPathIsDirectory_AsNSURL(
 // InitFileURLWithPathIsDirectoryRelativeToURL is undocumented.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1417932-initfileurlwithpath?language=objc for details.
-func (x gen_NSURL) InitFileURLWithPathIsDirectoryRelativeToURL_AsNSURL(
+func (x gen_NSURL) InitFileURLWithPathIsDirectoryRelativeToURL(
 	path NSStringRef,
 	isDir bool,
 	baseURL NSURLRef,
@@ -6579,7 +6579,7 @@ func (x gen_NSURL) InitFileURLWithPathIsDirectoryRelativeToURL_AsNSURL(
 // InitFileURLWithPathRelativeToURL is undocumented.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1415077-initfileurlwithpath?language=objc for details.
-func (x gen_NSURL) InitFileURLWithPathRelativeToURL_AsNSURL(
+func (x gen_NSURL) InitFileURLWithPathRelativeToURL(
 	path NSStringRef,
 	baseURL NSURLRef,
 ) NSURL {
@@ -6595,7 +6595,7 @@ func (x gen_NSURL) InitFileURLWithPathRelativeToURL_AsNSURL(
 // InitWithDataRepresentationRelativeToURL is undocumented.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1416851-initwithdatarepresentation?language=objc for details.
-func (x gen_NSURL) InitWithDataRepresentationRelativeToURL_AsNSURL(
+func (x gen_NSURL) InitWithDataRepresentationRelativeToURL(
 	data NSDataRef,
 	baseURL NSURLRef,
 ) NSURL {
@@ -6611,7 +6611,7 @@ func (x gen_NSURL) InitWithDataRepresentationRelativeToURL_AsNSURL(
 // InitWithString initializes an NSURL object with a provided URL string.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1413146-initwithstring?language=objc for details.
-func (x gen_NSURL) InitWithString_AsNSURL(
+func (x gen_NSURL) InitWithString(
 	URLString NSStringRef,
 ) NSURL {
 	ret := C.NSURL_inst_InitWithString(
@@ -6625,7 +6625,7 @@ func (x gen_NSURL) InitWithString_AsNSURL(
 // InitWithStringRelativeToURL initializes an NSURL object with a base URL and a relative string.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1417949-initwithstring?language=objc for details.
-func (x gen_NSURL) InitWithStringRelativeToURL_AsNSURL(
+func (x gen_NSURL) InitWithStringRelativeToURL(
 	URLString NSStringRef,
 	baseURL NSURLRef,
 ) NSURL {
@@ -6683,7 +6683,7 @@ func (x gen_NSURL) StopAccessingSecurityScopedResource() {
 }
 
 // Init is undocumented.
-func (x gen_NSURL) Init_AsNSURL() NSURL {
+func (x gen_NSURL) Init() NSURL {
 	ret := C.NSURL_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -6979,7 +6979,7 @@ func (x gen_NSURL) HasDirectoryPath() bool {
 
 type NSURLRequestRef interface {
 	Pointer() uintptr
-	Init_AsNSURLRequest() NSURLRequest
+	Init() NSURLRequest
 }
 
 type gen_NSURLRequest struct {
@@ -6999,7 +6999,7 @@ func NSURLRequest_FromRef(ref objc.Ref) NSURLRequest {
 // InitWithURL creates a URL request for a specified URL.
 //
 // See https://developer.apple.com/documentation/foundation/nsurlrequest/1410303-initwithurl?language=objc for details.
-func (x gen_NSURLRequest) InitWithURL_AsNSURLRequest(
+func (x gen_NSURLRequest) InitWithURL(
 	URL NSURLRef,
 ) NSURLRequest {
 	ret := C.NSURLRequest_inst_InitWithURL(
@@ -7025,7 +7025,7 @@ func (x gen_NSURLRequest) ValueForHTTPHeaderField(
 }
 
 // Init is undocumented.
-func (x gen_NSURLRequest) Init_AsNSURLRequest() NSURLRequest {
+func (x gen_NSURLRequest) Init() NSURLRequest {
 	ret := C.NSURLRequest_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -7156,7 +7156,7 @@ func (x gen_NSURLRequest) AssumesHTTP3Capable() bool {
 
 type NSUserDefaultsRef interface {
 	Pointer() uintptr
-	Init_AsNSUserDefaults() NSUserDefaults
+	Init() NSUserDefaults
 }
 
 type gen_NSUserDefaults struct {
@@ -7271,7 +7271,7 @@ func (x gen_NSUserDefaults) DictionaryRepresentation() NSDictionary {
 // Init creates a user defaults object initialized with the defaults for the app and current user.
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1414356-init?language=objc for details.
-func (x gen_NSUserDefaults) Init_AsNSUserDefaults() NSUserDefaults {
+func (x gen_NSUserDefaults) Init() NSUserDefaults {
 	ret := C.NSUserDefaults_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -7282,7 +7282,7 @@ func (x gen_NSUserDefaults) Init_AsNSUserDefaults() NSUserDefaults {
 // InitWithSuiteName creates a user defaults object initialized with the defaults for the specified database name.
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1409957-initwithsuitename?language=objc for details.
-func (x gen_NSUserDefaults) InitWithSuiteName_AsNSUserDefaults(
+func (x gen_NSUserDefaults) InitWithSuiteName(
 	suitename NSStringRef,
 ) NSUserDefaults {
 	ret := C.NSUserDefaults_inst_InitWithSuiteName(

--- a/core/core_objc.gen.go
+++ b/core/core_objc.gen.go
@@ -2823,7 +2823,7 @@ func NSUserDefaults_StandardUserDefaults() NSUserDefaults {
 
 type CALayerRef interface {
 	Pointer() uintptr
-	Init() CALayer
+	Init_AsCALayer() CALayer
 }
 
 type gen_CALayer struct {
@@ -2947,7 +2947,7 @@ func (x gen_CALayer) DisplayIfNeeded() {
 // Init returns an initialized CALayer object.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410835-init?language=objc for details.
-func (x gen_CALayer) Init() CALayer {
+func (x gen_CALayer) Init_AsCALayer() CALayer {
 	ret := C.CALayer_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4112,7 +4112,7 @@ func (x gen_CALayer) SetName(
 
 type NSArrayRef interface {
 	Pointer() uintptr
-	Init() NSArray
+	Init_AsNSArray() NSArray
 }
 
 type gen_NSArray struct {
@@ -4190,7 +4190,7 @@ func (x gen_NSArray) DescriptionWithLocaleIndent(
 // Init initializes a newly allocated array.
 //
 // See https://developer.apple.com/documentation/foundation/nsarray/1414315-init?language=objc for details.
-func (x gen_NSArray) Init() NSArray {
+func (x gen_NSArray) Init_AsNSArray() NSArray {
 	ret := C.NSArray_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4390,7 +4390,7 @@ func (x gen_NSArray) Description() NSString {
 
 type NSAttributedStringRef interface {
 	Pointer() uintptr
-	Init() NSAttributedString
+	Init_AsNSAttributedString() NSAttributedString
 }
 
 type gen_NSAttributedString struct {
@@ -4618,7 +4618,7 @@ func (x gen_NSAttributedString) Size() NSSize {
 }
 
 // Init is undocumented.
-func (x gen_NSAttributedString) Init() NSAttributedString {
+func (x gen_NSAttributedString) Init_AsNSAttributedString() NSAttributedString {
 	ret := C.NSAttributedString_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4650,7 +4650,7 @@ func (x gen_NSAttributedString) Length() NSUInteger {
 
 type NSDataRef interface {
 	Pointer() uintptr
-	Init() NSData
+	Init_AsNSData() NSData
 }
 
 type gen_NSData struct {
@@ -4822,7 +4822,7 @@ func (x gen_NSData) WriteToURLAtomically(
 }
 
 // Init is undocumented.
-func (x gen_NSData) Init() NSData {
+func (x gen_NSData) Init_AsNSData() NSData {
 	ret := C.NSData_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4865,7 +4865,7 @@ func (x gen_NSData) Description() NSString {
 
 type NSDictionaryRef interface {
 	Pointer() uintptr
-	Init() NSDictionary
+	Init_AsNSDictionary() NSDictionary
 }
 
 type gen_NSDictionary struct {
@@ -5036,7 +5036,7 @@ func (x gen_NSDictionary) FileType() NSString {
 // Init initializes a newly allocated dictionary.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1418147-init?language=objc for details.
-func (x gen_NSDictionary) Init() NSDictionary {
+func (x gen_NSDictionary) Init_AsNSDictionary() NSDictionary {
 	ret := C.NSDictionary_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5175,7 +5175,7 @@ func (x gen_NSDictionary) DescriptionInStringsFileFormat() NSString {
 
 type NSNumberRef interface {
 	Pointer() uintptr
-	Init() NSNumber
+	Init_AsNSNumber() NSNumber
 }
 
 type gen_NSNumber struct {
@@ -5291,7 +5291,7 @@ func (x gen_NSNumber) IsEqualToNumber(
 }
 
 // Init is undocumented.
-func (x gen_NSNumber) Init() NSNumber {
+func (x gen_NSNumber) Init_AsNSNumber() NSNumber {
 	ret := C.NSNumber_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5367,7 +5367,7 @@ func (x gen_NSNumber) StringValue() NSString {
 
 type NSRunLoopRef interface {
 	Pointer() uintptr
-	Init() NSRunLoop
+	Init_AsNSRunLoop() NSRunLoop
 }
 
 type gen_NSRunLoop struct {
@@ -5450,7 +5450,7 @@ func (x gen_NSRunLoop) Run() {
 }
 
 // Init is undocumented.
-func (x gen_NSRunLoop) Init() NSRunLoop {
+func (x gen_NSRunLoop) Init_AsNSRunLoop() NSRunLoop {
 	ret := C.NSRunLoop_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5460,7 +5460,7 @@ func (x gen_NSRunLoop) Init() NSRunLoop {
 
 type NSStringRef interface {
 	Pointer() uintptr
-	Init() NSString
+	Init_AsNSString() NSString
 }
 
 type gen_NSString struct {
@@ -5630,7 +5630,7 @@ func (x gen_NSString) HasSuffix(
 // Init returns an initialized NSString object that contains no characters.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1409306-init?language=objc for details.
-func (x gen_NSString) Init() NSString {
+func (x gen_NSString) Init_AsNSString() NSString {
 	ret := C.NSString_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -6265,7 +6265,7 @@ func (x gen_NSString) StringByRemovingPercentEncoding() NSString {
 
 type NSThreadRef interface {
 	Pointer() uintptr
-	Init() NSThread
+	Init_AsNSThread() NSThread
 }
 
 type gen_NSThread struct {
@@ -6296,7 +6296,7 @@ func (x gen_NSThread) Cancel() {
 // Init returns an initialized NSThread object.
 //
 // See https://developer.apple.com/documentation/foundation/nsthread/1416464-init?language=objc for details.
-func (x gen_NSThread) Init() NSThread {
+func (x gen_NSThread) Init_AsNSThread() NSThread {
 	ret := C.NSThread_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -6440,7 +6440,7 @@ func (x gen_NSThread) SetStackSize(
 
 type NSURLRef interface {
 	Pointer() uintptr
-	Init() NSURL
+	Init_AsNSURL() NSURL
 }
 
 type gen_NSURL struct {
@@ -6683,7 +6683,7 @@ func (x gen_NSURL) StopAccessingSecurityScopedResource() {
 }
 
 // Init is undocumented.
-func (x gen_NSURL) Init() NSURL {
+func (x gen_NSURL) Init_AsNSURL() NSURL {
 	ret := C.NSURL_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -6979,7 +6979,7 @@ func (x gen_NSURL) HasDirectoryPath() bool {
 
 type NSURLRequestRef interface {
 	Pointer() uintptr
-	Init() NSURLRequest
+	Init_AsNSURLRequest() NSURLRequest
 }
 
 type gen_NSURLRequest struct {
@@ -7025,7 +7025,7 @@ func (x gen_NSURLRequest) ValueForHTTPHeaderField(
 }
 
 // Init is undocumented.
-func (x gen_NSURLRequest) Init() NSURLRequest {
+func (x gen_NSURLRequest) Init_AsNSURLRequest() NSURLRequest {
 	ret := C.NSURLRequest_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -7156,7 +7156,7 @@ func (x gen_NSURLRequest) AssumesHTTP3Capable() bool {
 
 type NSUserDefaultsRef interface {
 	Pointer() uintptr
-	Init() NSUserDefaults
+	Init_AsNSUserDefaults() NSUserDefaults
 }
 
 type gen_NSUserDefaults struct {
@@ -7271,7 +7271,7 @@ func (x gen_NSUserDefaults) DictionaryRepresentation() NSDictionary {
 // Init creates a user defaults object initialized with the defaults for the app and current user.
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1414356-init?language=objc for details.
-func (x gen_NSUserDefaults) Init() NSUserDefaults {
+func (x gen_NSUserDefaults) Init_AsNSUserDefaults() NSUserDefaults {
 	ret := C.NSUserDefaults_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)

--- a/core/core_objc.gen.go
+++ b/core/core_objc.gen.go
@@ -2947,7 +2947,7 @@ func (x gen_CALayer) DisplayIfNeeded() {
 // Init returns an initialized CALayer object.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410835-init?language=objc for details.
-func (x gen_CALayer) Init_AsCALayer() CALayer {
+func (x gen_CALayer) Init() CALayer {
 	ret := C.CALayer_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4190,7 +4190,7 @@ func (x gen_NSArray) DescriptionWithLocaleIndent(
 // Init initializes a newly allocated array.
 //
 // See https://developer.apple.com/documentation/foundation/nsarray/1414315-init?language=objc for details.
-func (x gen_NSArray) Init_AsNSArray() NSArray {
+func (x gen_NSArray) Init() NSArray {
 	ret := C.NSArray_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4618,7 +4618,7 @@ func (x gen_NSAttributedString) Size() NSSize {
 }
 
 // Init is undocumented.
-func (x gen_NSAttributedString) Init_AsNSAttributedString() NSAttributedString {
+func (x gen_NSAttributedString) Init() NSAttributedString {
 	ret := C.NSAttributedString_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -4822,7 +4822,7 @@ func (x gen_NSData) WriteToURLAtomically(
 }
 
 // Init is undocumented.
-func (x gen_NSData) Init_AsNSData() NSData {
+func (x gen_NSData) Init() NSData {
 	ret := C.NSData_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5036,7 +5036,7 @@ func (x gen_NSDictionary) FileType() NSString {
 // Init initializes a newly allocated dictionary.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1418147-init?language=objc for details.
-func (x gen_NSDictionary) Init_AsNSDictionary() NSDictionary {
+func (x gen_NSDictionary) Init() NSDictionary {
 	ret := C.NSDictionary_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5291,7 +5291,7 @@ func (x gen_NSNumber) IsEqualToNumber(
 }
 
 // Init is undocumented.
-func (x gen_NSNumber) Init_AsNSNumber() NSNumber {
+func (x gen_NSNumber) Init() NSNumber {
 	ret := C.NSNumber_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5450,7 +5450,7 @@ func (x gen_NSRunLoop) Run() {
 }
 
 // Init is undocumented.
-func (x gen_NSRunLoop) Init_AsNSRunLoop() NSRunLoop {
+func (x gen_NSRunLoop) Init() NSRunLoop {
 	ret := C.NSRunLoop_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -5630,7 +5630,7 @@ func (x gen_NSString) HasSuffix(
 // Init returns an initialized NSString object that contains no characters.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1409306-init?language=objc for details.
-func (x gen_NSString) Init_AsNSString() NSString {
+func (x gen_NSString) Init() NSString {
 	ret := C.NSString_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -6296,7 +6296,7 @@ func (x gen_NSThread) Cancel() {
 // Init returns an initialized NSThread object.
 //
 // See https://developer.apple.com/documentation/foundation/nsthread/1416464-init?language=objc for details.
-func (x gen_NSThread) Init_AsNSThread() NSThread {
+func (x gen_NSThread) Init() NSThread {
 	ret := C.NSThread_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -6683,7 +6683,7 @@ func (x gen_NSURL) StopAccessingSecurityScopedResource() {
 }
 
 // Init is undocumented.
-func (x gen_NSURL) Init_AsNSURL() NSURL {
+func (x gen_NSURL) Init() NSURL {
 	ret := C.NSURL_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -7025,7 +7025,7 @@ func (x gen_NSURLRequest) ValueForHTTPHeaderField(
 }
 
 // Init is undocumented.
-func (x gen_NSURLRequest) Init_AsNSURLRequest() NSURLRequest {
+func (x gen_NSURLRequest) Init() NSURLRequest {
 	ret := C.NSURLRequest_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -7271,7 +7271,7 @@ func (x gen_NSUserDefaults) DictionaryRepresentation() NSDictionary {
 // Init creates a user defaults object initialized with the defaults for the app and current user.
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1414356-init?language=objc for details.
-func (x gen_NSUserDefaults) Init_AsNSUserDefaults() NSUserDefaults {
+func (x gen_NSUserDefaults) Init() NSUserDefaults {
 	ret := C.NSUserDefaults_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)

--- a/examples/largetype/main.go
+++ b/examples/largetype/main.go
@@ -20,6 +20,7 @@ func main() {
 
 		screen := cocoa.NSScreen_Main().Frame().Size
 		text := fmt.Sprintf(" %s ", strings.Join(flag.Args(), " "))
+		fmt.Println(text)
 		tr, fontSize := func() (rect core.NSRect, size float64) {
 			t := cocoa.NSTextView_Init(core.Rect(0, 0, 0, 0))
 			t.SetString(text)
@@ -65,7 +66,7 @@ func main() {
 		w.SetFrameDisplay(tr, true)
 		w.MakeKeyAndOrderFront(nil)
 
-		events := make(chan cocoa.NSEvent, 64)
+		events := make(chan cocoa.NSEvent, 964)
 		go func() {
 			<-events
 			cocoa.NSApp().Terminate()

--- a/examples/notification/main.go
+++ b/examples/notification/main.go
@@ -20,7 +20,7 @@ var NSUserNotificationCenter_ = objc.Get("NSUserNotificationCenter")
 
 func main() {
 	app := cocoa.NSApp_WithDidLaunch(func(_ objc.Object) {
-		notification := NSUserNotification{NSUserNotification_.Alloc().Init()}
+		notification := NSUserNotification{NSUserNotification_.Alloc().InitObject()}
 		notification.Set("title:", core.String("Hello, world!"))
 		notification.Set("informativeText:", core.String("More text"))
 

--- a/examples/subclass/main.go
+++ b/examples/subclass/main.go
@@ -42,7 +42,7 @@ func main() {
 		win.SetTitle("Hello world")
 		win.SetLevel(cocoa.NSMainMenuWindowLevel + 2)
 
-		view := objc.Get("TestView").Alloc().Init()
+		view := objc.Get("TestView").Alloc().InitObject()
 		win.Set("ContentView:", view)
 		win.MakeKeyAndOrderFront(nil)
 

--- a/gen/convert.go
+++ b/gen/convert.go
@@ -80,6 +80,14 @@ func processClassSchema(pkg *GoPackage, s *schema.Schema, imports []PackageConte
 
 		classDef.InstanceMethods = append(classDef.InstanceMethods, method)
 		pkg.MsgSendWrappers = append(pkg.MsgSendWrappers, msg)
+		// handle typed init methods
+		if m.Name == "init" {
+			method.Name += fmt.Sprintf("_As%s", cb.Class.Name)
+			m.Description = "is a typed version of Init."
+			method.Description = formatComment(m, method.Name)
+			classDef.InstanceMethods = append(classDef.InstanceMethods, method)
+		}
+
 	})
 
 	return classDef, nil

--- a/gen/gen_class_builder.go
+++ b/gen/gen_class_builder.go
@@ -68,9 +68,6 @@ func (cb *classBuilder) instanceMethod(method schema.Method) MethodDef {
 		Name:        ident,
 		WrappedFunc: cb.cgoWrapperFunc(method, false),
 	}
-	if method.Name == "init" && isInstanceType(method.Return) {
-		r.Name += "_As" + cb.Class.Name
-	}
 	return r
 }
 

--- a/gen/gen_class_builder.go
+++ b/gen/gen_class_builder.go
@@ -63,6 +63,12 @@ func (cb *classBuilder) EachInstanceMethod(f func(schema.Method)) {
 
 func (cb *classBuilder) instanceMethod(method schema.Method) MethodDef {
 	ident := toExportedName(selectorNameToGoIdent(cb.generatedNames, method.Name))
+
+	// populate init description if it's empty.
+	if method.Name == "init" && method.Description == "" {
+		method.Description = fmt.Sprintf("initializes a new instance of the %s class.", cb.Class.Name)
+	}
+
 	r := MethodDef{
 		Description: formatComment(method, ident),
 		Name:        ident,

--- a/gen/gen_class_builder.go
+++ b/gen/gen_class_builder.go
@@ -68,6 +68,9 @@ func (cb *classBuilder) instanceMethod(method schema.Method) MethodDef {
 		Name:        ident,
 		WrappedFunc: cb.cgoWrapperFunc(method, false),
 	}
+	if method.Name == "init" && isInstanceType(method.Return) {
+		r.Name += "_As" + cb.Class.Name
+	}
 	return r
 }
 

--- a/gen/gen_class_builder.go
+++ b/gen/gen_class_builder.go
@@ -68,9 +68,6 @@ func (cb *classBuilder) instanceMethod(method schema.Method) MethodDef {
 		Name:        ident,
 		WrappedFunc: cb.cgoWrapperFunc(method, false),
 	}
-	if isInstanceType(method.Return) {
-		r.Name += "_As" + cb.Class.Name
-	}
 	return r
 }
 

--- a/gen/template/package.tmpl
+++ b/gen/template/package.tmpl
@@ -121,7 +121,7 @@ func {{.Name}}(
 {{range $cls := .}}
 type {{.Name}}Ref interface {
 	Pointer() uintptr
-	Init() {{.Name}}
+	Init_As{{.Name}}() {{.Name}}
 }
 
 type gen_{{.Name}} struct {

--- a/gen/template/package.tmpl
+++ b/gen/template/package.tmpl
@@ -121,7 +121,7 @@ func {{.Name}}(
 {{range $cls := .}}
 type {{.Name}}Ref interface {
 	Pointer() uintptr
-	Init_As{{.Name}}() {{.Name}}
+	Init() {{.Name}}
 }
 
 type gen_{{.Name}} struct {

--- a/objc/autoreleasepool_test.go
+++ b/objc/autoreleasepool_test.go
@@ -18,7 +18,7 @@ func TestAutorelease(t *testing.T) {
 	RegisterClass(c)
 
 	Autorelease(func() {
-		dc := GetClass("AutoreleaseDealloc").Alloc().Init()
+		dc := GetClass("AutoreleaseDealloc").Alloc().InitObject()
 		dc.Autorelease()
 	})
 	if deallocCount != 1 {

--- a/objc/object.go
+++ b/objc/object.go
@@ -42,7 +42,9 @@ type Object interface {
 	Alloc() Object
 
 	// Init sends the "init" message to the object.
-	Init() Object
+	// We name this InitObject to avoid a name clash with generated
+	// Init methods that have a different signature.
+	InitObject() Object
 
 	// Retain sends the "retain" message to the object.
 	Retain() Object
@@ -135,7 +137,7 @@ func (obj object) Alloc() Object {
 	return obj.Send("alloc")
 }
 
-func (obj object) Init() Object {
+func (obj object) InitObject() Object {
 	return obj.Send("init")
 }
 

--- a/webkit/WKWebView.go
+++ b/webkit/WKWebView.go
@@ -10,7 +10,7 @@ type WKWebView struct {
 }
 
 func WKWebView_Init(frame core.NSRect, config WKWebViewConfiguration) WKWebView {
-	return WKWebView_Alloc().InitWithFrameConfiguration_AsWKWebView(frame, config)
+	return WKWebView_Alloc().InitWithFrameConfiguration(frame, config)
 }
 
 // FIXME this would conflict with the `reload` selector that doesn't take a

--- a/webkit/webkit_objc.gen.go
+++ b/webkit/webkit_objc.gen.go
@@ -527,7 +527,7 @@ func WKPreferences_Alloc() WKPreferences {
 
 type WKNavigationRef interface {
 	Pointer() uintptr
-	Init() WKNavigation
+	Init_AsWKNavigation() WKNavigation
 }
 
 type gen_WKNavigation struct {
@@ -545,7 +545,7 @@ func WKNavigation_FromRef(ref objc.Ref) WKNavigation {
 }
 
 // Init is undocumented.
-func (x gen_WKNavigation) Init() WKNavigation {
+func (x gen_WKNavigation) Init_AsWKNavigation() WKNavigation {
 	ret := C.WKNavigation_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -555,7 +555,7 @@ func (x gen_WKNavigation) Init() WKNavigation {
 
 type WKUserScriptRef interface {
 	Pointer() uintptr
-	Init() WKUserScript
+	Init_AsWKUserScript() WKUserScript
 }
 
 type gen_WKUserScript struct {
@@ -573,7 +573,7 @@ func WKUserScript_FromRef(ref objc.Ref) WKUserScript {
 }
 
 // Init is undocumented.
-func (x gen_WKUserScript) Init() WKUserScript {
+func (x gen_WKUserScript) Init_AsWKUserScript() WKUserScript {
 	ret := C.WKUserScript_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -605,7 +605,7 @@ func (x gen_WKUserScript) IsForMainFrameOnly() bool {
 
 type WKWebViewRef interface {
 	Pointer() uintptr
-	Init() WKWebView
+	Init_AsWKWebView() WKWebView
 }
 
 type gen_WKWebView struct {
@@ -862,7 +862,7 @@ func (x gen_WKWebView) StopLoading_(
 }
 
 // Init is undocumented.
-func (x gen_WKWebView) Init() WKWebView {
+func (x gen_WKWebView) Init_AsWKWebView() WKWebView {
 	ret := C.WKWebView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -1174,7 +1174,7 @@ func (x gen_WKWebView) SetInteractionState(
 
 type WKWebViewConfigurationRef interface {
 	Pointer() uintptr
-	Init() WKWebViewConfiguration
+	Init_AsWKWebViewConfiguration() WKWebViewConfiguration
 }
 
 type gen_WKWebViewConfiguration struct {
@@ -1222,7 +1222,7 @@ func (x gen_WKWebViewConfiguration) UrlSchemeHandlerForURLScheme(
 }
 
 // Init is undocumented.
-func (x gen_WKWebViewConfiguration) Init() WKWebViewConfiguration {
+func (x gen_WKWebViewConfiguration) Init_AsWKWebViewConfiguration() WKWebViewConfiguration {
 	ret := C.WKWebViewConfiguration_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -1457,7 +1457,7 @@ func (x gen_WKWebViewConfiguration) SetUpgradeKnownHostsToHTTPS(
 
 type WKPreferencesRef interface {
 	Pointer() uintptr
-	Init() WKPreferences
+	Init_AsWKPreferences() WKPreferences
 }
 
 type gen_WKPreferences struct {
@@ -1489,7 +1489,7 @@ func (x gen_WKPreferences) SetValueForKey(
 }
 
 // Init is undocumented.
-func (x gen_WKPreferences) Init() WKPreferences {
+func (x gen_WKPreferences) Init_AsWKPreferences() WKPreferences {
 	ret := C.WKPreferences_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)

--- a/webkit/webkit_objc.gen.go
+++ b/webkit/webkit_objc.gen.go
@@ -544,8 +544,17 @@ func WKNavigation_FromRef(ref objc.Ref) WKNavigation {
 	return WKNavigation_FromPointer(unsafe.Pointer(ref.Pointer()))
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the WKNavigation class.
 func (x gen_WKNavigation) Init() WKNavigation {
+	ret := C.WKNavigation_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return WKNavigation_FromPointer(ret)
+}
+
+// Init_AsWKNavigation is a typed version of Init.
+func (x gen_WKNavigation) Init_AsWKNavigation() WKNavigation {
 	ret := C.WKNavigation_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -572,8 +581,17 @@ func WKUserScript_FromRef(ref objc.Ref) WKUserScript {
 	return WKUserScript_FromPointer(unsafe.Pointer(ref.Pointer()))
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the WKUserScript class.
 func (x gen_WKUserScript) Init() WKUserScript {
+	ret := C.WKUserScript_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return WKUserScript_FromPointer(ret)
+}
+
+// Init_AsWKUserScript is a typed version of Init.
+func (x gen_WKUserScript) Init_AsWKUserScript() WKUserScript {
 	ret := C.WKUserScript_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -861,8 +879,17 @@ func (x gen_WKWebView) StopLoading_(
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the WKWebView class.
 func (x gen_WKWebView) Init() WKWebView {
+	ret := C.WKWebView_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return WKWebView_FromPointer(ret)
+}
+
+// Init_AsWKWebView is a typed version of Init.
+func (x gen_WKWebView) Init_AsWKWebView() WKWebView {
 	ret := C.WKWebView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -1221,8 +1248,17 @@ func (x gen_WKWebViewConfiguration) UrlSchemeHandlerForURLScheme(
 	return objc.Object_FromPointer(ret)
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the WKWebViewConfiguration class.
 func (x gen_WKWebViewConfiguration) Init() WKWebViewConfiguration {
+	ret := C.WKWebViewConfiguration_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return WKWebViewConfiguration_FromPointer(ret)
+}
+
+// Init_AsWKWebViewConfiguration is a typed version of Init.
+func (x gen_WKWebViewConfiguration) Init_AsWKWebViewConfiguration() WKWebViewConfiguration {
 	ret := C.WKWebViewConfiguration_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -1488,8 +1524,17 @@ func (x gen_WKPreferences) SetValueForKey(
 	return
 }
 
-// Init is undocumented.
+// Init initializes a new instance of the WKPreferences class.
 func (x gen_WKPreferences) Init() WKPreferences {
+	ret := C.WKPreferences_inst_Init(
+		unsafe.Pointer(x.Pointer()),
+	)
+
+	return WKPreferences_FromPointer(ret)
+}
+
+// Init_AsWKPreferences is a typed version of Init.
+func (x gen_WKPreferences) Init_AsWKPreferences() WKPreferences {
 	ret := C.WKPreferences_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)

--- a/webkit/webkit_objc.gen.go
+++ b/webkit/webkit_objc.gen.go
@@ -527,7 +527,7 @@ func WKPreferences_Alloc() WKPreferences {
 
 type WKNavigationRef interface {
 	Pointer() uintptr
-	Init_AsWKNavigation() WKNavigation
+	Init() WKNavigation
 }
 
 type gen_WKNavigation struct {
@@ -545,7 +545,7 @@ func WKNavigation_FromRef(ref objc.Ref) WKNavigation {
 }
 
 // Init is undocumented.
-func (x gen_WKNavigation) Init_AsWKNavigation() WKNavigation {
+func (x gen_WKNavigation) Init() WKNavigation {
 	ret := C.WKNavigation_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -555,7 +555,7 @@ func (x gen_WKNavigation) Init_AsWKNavigation() WKNavigation {
 
 type WKUserScriptRef interface {
 	Pointer() uintptr
-	Init_AsWKUserScript() WKUserScript
+	Init() WKUserScript
 }
 
 type gen_WKUserScript struct {
@@ -573,7 +573,7 @@ func WKUserScript_FromRef(ref objc.Ref) WKUserScript {
 }
 
 // Init is undocumented.
-func (x gen_WKUserScript) Init_AsWKUserScript() WKUserScript {
+func (x gen_WKUserScript) Init() WKUserScript {
 	ret := C.WKUserScript_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -605,7 +605,7 @@ func (x gen_WKUserScript) IsForMainFrameOnly() bool {
 
 type WKWebViewRef interface {
 	Pointer() uintptr
-	Init_AsWKWebView() WKWebView
+	Init() WKWebView
 }
 
 type gen_WKWebView struct {
@@ -675,7 +675,7 @@ func (x gen_WKWebView) GoForward_(
 // InitWithFrameConfiguration creates a web view and initializes it with the specified frame and configuration data.
 //
 // See https://developer.apple.com/documentation/webkit/wkwebview/1414998-initwithframe?language=objc for details.
-func (x gen_WKWebView) InitWithFrameConfiguration_AsWKWebView(
+func (x gen_WKWebView) InitWithFrameConfiguration(
 	frame core.NSRect,
 	configuration WKWebViewConfigurationRef,
 ) WKWebView {
@@ -862,7 +862,7 @@ func (x gen_WKWebView) StopLoading_(
 }
 
 // Init is undocumented.
-func (x gen_WKWebView) Init_AsWKWebView() WKWebView {
+func (x gen_WKWebView) Init() WKWebView {
 	ret := C.WKWebView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -1174,7 +1174,7 @@ func (x gen_WKWebView) SetInteractionState(
 
 type WKWebViewConfigurationRef interface {
 	Pointer() uintptr
-	Init_AsWKWebViewConfiguration() WKWebViewConfiguration
+	Init() WKWebViewConfiguration
 }
 
 type gen_WKWebViewConfiguration struct {
@@ -1222,7 +1222,7 @@ func (x gen_WKWebViewConfiguration) UrlSchemeHandlerForURLScheme(
 }
 
 // Init is undocumented.
-func (x gen_WKWebViewConfiguration) Init_AsWKWebViewConfiguration() WKWebViewConfiguration {
+func (x gen_WKWebViewConfiguration) Init() WKWebViewConfiguration {
 	ret := C.WKWebViewConfiguration_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -1457,7 +1457,7 @@ func (x gen_WKWebViewConfiguration) SetUpgradeKnownHostsToHTTPS(
 
 type WKPreferencesRef interface {
 	Pointer() uintptr
-	Init_AsWKPreferences() WKPreferences
+	Init() WKPreferences
 }
 
 type gen_WKPreferences struct {
@@ -1489,7 +1489,7 @@ func (x gen_WKPreferences) SetValueForKey(
 }
 
 // Init is undocumented.
-func (x gen_WKPreferences) Init_AsWKPreferences() WKPreferences {
+func (x gen_WKPreferences) Init() WKPreferences {
 	ret := C.WKPreferences_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)

--- a/webkit/webkit_objc.gen.go
+++ b/webkit/webkit_objc.gen.go
@@ -545,7 +545,7 @@ func WKNavigation_FromRef(ref objc.Ref) WKNavigation {
 }
 
 // Init is undocumented.
-func (x gen_WKNavigation) Init_AsWKNavigation() WKNavigation {
+func (x gen_WKNavigation) Init() WKNavigation {
 	ret := C.WKNavigation_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -573,7 +573,7 @@ func WKUserScript_FromRef(ref objc.Ref) WKUserScript {
 }
 
 // Init is undocumented.
-func (x gen_WKUserScript) Init_AsWKUserScript() WKUserScript {
+func (x gen_WKUserScript) Init() WKUserScript {
 	ret := C.WKUserScript_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -862,7 +862,7 @@ func (x gen_WKWebView) StopLoading_(
 }
 
 // Init is undocumented.
-func (x gen_WKWebView) Init_AsWKWebView() WKWebView {
+func (x gen_WKWebView) Init() WKWebView {
 	ret := C.WKWebView_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -1222,7 +1222,7 @@ func (x gen_WKWebViewConfiguration) UrlSchemeHandlerForURLScheme(
 }
 
 // Init is undocumented.
-func (x gen_WKWebViewConfiguration) Init_AsWKWebViewConfiguration() WKWebViewConfiguration {
+func (x gen_WKWebViewConfiguration) Init() WKWebViewConfiguration {
 	ret := C.WKWebViewConfiguration_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)
@@ -1489,7 +1489,7 @@ func (x gen_WKPreferences) SetValueForKey(
 }
 
 // Init is undocumented.
-func (x gen_WKPreferences) Init_AsWKPreferences() WKPreferences {
+func (x gen_WKPreferences) Init() WKPreferences {
 	ret := C.WKPreferences_inst_Init(
 		unsafe.Pointer(x.Pointer()),
 	)


### PR DESCRIPTION
This shortens up have many of these constructors/initialization methods.

I have not yet done so for the bear inits in part because it would mean that classes no longer easily satisfy the core.Object interface. Let's discuss further.

0.4.0 vs after this:
<img width="735" alt="Screenshot 2023-07-08 at 11 35 55 AM" src="https://github.com/progrium/macdriver/assets/3977/08259200-06c3-4575-b0a0-f1c3aadcdacd">

<img width="609" alt="Screenshot 2023-07-08 at 11 35 45 AM" src="https://github.com/progrium/macdriver/assets/3977/c67ce293-3d8c-45a9-85b9-997c74f60b6f">

Fixes #124


