### PR TITLE
Make the API more Go-like by allowing the use of Go's string type in place of NSString

### DIFF
--- a/cocoa/NSEvent.go
+++ b/cocoa/NSEvent.go
@@ -133,5 +133,5 @@ func (e NSEvent) Characters() (string, error) {
 	if eventType != NSEventTypeKeyDown && eventType != NSEventTypeKeyUp {
 		return "", errors.New("event does not contain characters")
 	}
-	return e.gen_NSEvent.Characters().String(), nil
+	return e.gen_NSEvent.Characters(), nil
 }

--- a/cocoa/NSFont.go
+++ b/cocoa/NSFont.go
@@ -1,3 +1,14 @@
 package cocoa
 
+import (
+	"github.com/progrium/macdriver/core"
+)
+
 type NSFont struct{ gen_NSFont }
+
+func NSFont_Init(fontName string, size float64) NSFont {
+	return NSFont_FontWithNameSize(
+		fontName,
+		core.CGFloat(size),
+	)
+}

--- a/cocoa/NSFont.go
+++ b/cocoa/NSFont.go
@@ -1,14 +1,3 @@
 package cocoa
 
-import (
-	"github.com/progrium/macdriver/core"
-)
-
 type NSFont struct{ gen_NSFont }
-
-func NSFont_Init(fontName string, size float64) NSFont {
-	return NSFont_FontWithNameSize(
-		core.String(fontName),
-		core.CGFloat(size),
-	)
-}

--- a/cocoa/NSMenu.go
+++ b/cocoa/NSMenu.go
@@ -1,9 +1,5 @@
 package cocoa
 
-import (
-	"github.com/progrium/macdriver/core"
-)
-
 type NSMenu struct {
 	gen_NSMenu
 }
@@ -13,9 +9,9 @@ func NSMenu_New() NSMenu {
 }
 
 func NSMenu_Init(title string) NSMenu {
-	return NSMenu_Alloc().InitWithTitle(core.String(title))
+	return NSMenu_Alloc().InitWithTitle(title)
 }
 
 func (menu NSMenu) Title() string {
-	return menu.gen_NSMenu.Title().String()
+	return menu.gen_NSMenu.Title()
 }

--- a/cocoa/NSMenuItem.go
+++ b/cocoa/NSMenuItem.go
@@ -11,13 +11,6 @@ type NSMenuItem struct {
 	gen_NSMenuItem
 }
 
-// NSMenuItem_Init returns an initialized instance of NSMenuItem.
-// https://developer.apple.com/documentation/appkit/nsmenuitem/1514858-initwithtitle?language=objc
-func NSMenuItem_Init(itemName string, action objc.Selector, keyEquivalent string) NSMenuItem {
-	return NSMenuItem_Alloc().InitWithTitleActionKeyEquivalent(
-		core.String(itemName), action, core.String(keyEquivalent))
-}
-
 // NSMenuItem_New returns an initialized instance of NSMenuItem.
 func NSMenuItem_New() NSMenuItem {
 	return NSMenuItem_Alloc().Init()
@@ -41,34 +34,10 @@ func (i NSMenuItem) Enabled() bool {
 	return i.IsEnabled()
 }
 
-// Title returns the menu item's title.
-// https://developer.apple.com/documentation/appkit/nsmenuitem/1514805-title?language=objc
-func (i NSMenuItem) Title() string {
-	return i.gen_NSMenuItem.Title().String()
-}
-
-// SetTitle sets the menu item's title.
-// https://developer.apple.com/documentation/appkit/nsmenuitem/1514805-title?language=objc
-func (i NSMenuItem) SetTitle(s string) {
-	i.gen_NSMenuItem.SetTitle(core.String(s))
-}
-
 // SetAttributedTitle sets a custom string for the menu item's title.
 // https://developer.apple.com/documentation/appkit/nsmenuitem/1514860-attributedtitle?language=objc
 func (i NSMenuItem) SetAttributedTitle(s string) {
 	i.gen_NSMenuItem.SetAttributedTitle(core.NSAttributedString_FromString(s))
-}
-
-// ToolTip returns a help tag for the menu item.
-// https://developer.apple.com/documentation/appkit/nsmenuitem/1514848-tooltip?language=objc
-func (i NSMenuItem) ToolTip() string {
-	return i.gen_NSMenuItem.ToolTip().String()
-}
-
-// SetToolTip sets a help tag for the menu item.
-// https://developer.apple.com/documentation/appkit/nsmenuitem/1514848-tooltip?language=objc
-func (i NSMenuItem) SetToolTip(s string) {
-	i.gen_NSMenuItem.SetToolTip(core.String(s))
 }
 
 // Target returns the menu item's target.

--- a/cocoa/NSStatusBarButton.go
+++ b/cocoa/NSStatusBarButton.go
@@ -21,7 +21,7 @@ func (b NSStatusBarButton) Title() string {
 }
 
 func (b NSStatusBarButton) SetTitle(s string) {
-	b.gen_NSStatusBarButton.SetTitle(core.String(s))
+	b.gen_NSStatusBarButton.SetTitle(s)
 }
 
 func (b NSStatusBarButton) ToolTip() string {

--- a/cocoa/NSTextView.go
+++ b/cocoa/NSTextView.go
@@ -23,11 +23,11 @@ func NSTextView_Init(frame core.NSRect) NSTextView {
 }
 
 func (v NSTextView) String() string {
-	return v.gen_NSTextView.String().String()
+	return v.gen_NSTextView.String()
 }
 
 func (v NSTextView) SetString(s string) {
-	v.gen_NSTextView.SetString(core.String(s))
+	v.gen_NSTextView.SetString(s)
 }
 
 func (v NSTextView) Selectable() bool {

--- a/cocoa/NSWindow.go
+++ b/cocoa/NSWindow.go
@@ -42,11 +42,11 @@ func (w NSWindow) StyleMask() uint {
 }
 
 func (w NSWindow) SetTitle(title string) {
-	w.gen_NSWindow.SetTitle(core.String(title))
+	w.gen_NSWindow.SetTitle(title)
 }
 
 func (w NSWindow) Title() string {
-	return w.gen_NSWindow.Title().String()
+	return w.gen_NSWindow.Title()
 }
 
 func (w NSWindow) SetTitleVisibility(v int) {

--- a/cocoa/cocoa_objc.gen.go
+++ b/cocoa/cocoa_objc.gen.go
@@ -21,6 +21,17 @@ bool cocoa_convertObjCBool(BOOL b) {
 	return false;
 }
 
+// Creates a NSString from a C string
+static void *createNSStringFromCString(char *cString) {
+    return [NSString stringWithCString: cString encoding: NSUTF8StringEncoding];
+}
+
+// Creates a C string from a NSString
+static char *createCStringFromNSString(void *objcString)
+{
+    return [objcString UTF8String];
+}
+
 
 void* NSBundle_type_Alloc() {
 	return [NSBundle
@@ -7734,9 +7745,9 @@ func NSBundle_BundleWithURL(url core.NSURLRef) NSBundle {
 // NSBundle_BundleWithPath returns an NSBundle object that corresponds to the specified directory.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1495012-bundlewithpath?language=objc for details.
-func NSBundle_BundleWithPath(path core.NSStringRef) NSBundle {
+func NSBundle_BundleWithPath(path string) NSBundle {
 	ret := C.NSBundle_type_BundleWithPath(
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 	)
 
 	return NSBundle_FromPointer(ret)
@@ -7745,9 +7756,9 @@ func NSBundle_BundleWithPath(path core.NSStringRef) NSBundle {
 // NSBundle_BundleWithIdentifier returns the NSBundle instance that has the specified bundle identifier.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1411929-bundlewithidentifier?language=objc for details.
-func NSBundle_BundleWithIdentifier(identifier core.NSStringRef) NSBundle {
+func NSBundle_BundleWithIdentifier(identifier string) NSBundle {
 	ret := C.NSBundle_type_BundleWithIdentifier(
-		objc.RefPointer(identifier),
+		C.createNSStringFromCString(C.CString(identifier)),
 	)
 
 	return NSBundle_FromPointer(ret)
@@ -7756,11 +7767,11 @@ func NSBundle_BundleWithIdentifier(identifier core.NSStringRef) NSBundle {
 // NSBundle_URLForResourceWithExtensionSubdirectoryInBundleWithURL creates and returns a file URL for the resource with the specified name and extension in the specified bundle.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1416361-urlforresource?language=objc for details.
-func NSBundle_URLForResourceWithExtensionSubdirectoryInBundleWithURL(name core.NSStringRef, ext core.NSStringRef, subpath core.NSStringRef, bundleURL core.NSURLRef) core.NSURL {
+func NSBundle_URLForResourceWithExtensionSubdirectoryInBundleWithURL(name string, ext string, subpath string, bundleURL core.NSURLRef) core.NSURL {
 	ret := C.NSBundle_type_URLForResourceWithExtensionSubdirectoryInBundleWithURL(
-		objc.RefPointer(name),
-		objc.RefPointer(ext),
-		objc.RefPointer(subpath),
+		C.createNSStringFromCString(C.CString(name)),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(subpath)),
 		objc.RefPointer(bundleURL),
 	)
 
@@ -7770,10 +7781,10 @@ func NSBundle_URLForResourceWithExtensionSubdirectoryInBundleWithURL(name core.N
 // NSBundle_URLsForResourcesWithExtensionSubdirectoryInBundleWithURL returns an array containing the file URLs for all bundle resources having the specified filename extension, residing in the specified resource subdirectory, within the specified bundle.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1409807-urlsforresourceswithextension?language=objc for details.
-func NSBundle_URLsForResourcesWithExtensionSubdirectoryInBundleWithURL(ext core.NSStringRef, subpath core.NSStringRef, bundleURL core.NSURLRef) core.NSArray {
+func NSBundle_URLsForResourcesWithExtensionSubdirectoryInBundleWithURL(ext string, subpath string, bundleURL core.NSURLRef) core.NSArray {
 	ret := C.NSBundle_type_URLsForResourcesWithExtensionSubdirectoryInBundleWithURL(
-		objc.RefPointer(ext),
-		objc.RefPointer(subpath),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(subpath)),
 		objc.RefPointer(bundleURL),
 	)
 
@@ -7783,23 +7794,23 @@ func NSBundle_URLsForResourcesWithExtensionSubdirectoryInBundleWithURL(ext core.
 // NSBundle_PathForResourceOfTypeInDirectory returns the full pathname for the resource file identified by the specified name and extension and residing in a given bundle directory.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1409523-pathforresource?language=objc for details.
-func NSBundle_PathForResourceOfTypeInDirectory(name core.NSStringRef, ext core.NSStringRef, bundlePath core.NSStringRef) core.NSString {
+func NSBundle_PathForResourceOfTypeInDirectory(name string, ext string, bundlePath string) string {
 	ret := C.NSBundle_type_PathForResourceOfTypeInDirectory(
-		objc.RefPointer(name),
-		objc.RefPointer(ext),
-		objc.RefPointer(bundlePath),
+		C.createNSStringFromCString(C.CString(name)),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(bundlePath)),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // NSBundle_PathsForResourcesOfTypeInDirectory returns an array containing the pathnames for all bundle resources having the specified extension and residing in the bundle directory at the specified path.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1415876-pathsforresourcesoftype?language=objc for details.
-func NSBundle_PathsForResourcesOfTypeInDirectory(ext core.NSStringRef, bundlePath core.NSStringRef) core.NSArray {
+func NSBundle_PathsForResourcesOfTypeInDirectory(ext string, bundlePath string) core.NSArray {
 	ret := C.NSBundle_type_PathsForResourcesOfTypeInDirectory(
-		objc.RefPointer(ext),
-		objc.RefPointer(bundlePath),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(bundlePath)),
 	)
 
 	return core.NSArray_FromPointer(ret)
@@ -7928,9 +7939,9 @@ func NSButton_Alloc() NSButton {
 // NSButton_CheckboxWithTitleTargetAction creates a standard checkbox with the title you specify.
 //
 // See https://developer.apple.com/documentation/appkit/nsbutton/1644525-checkboxwithtitle?language=objc for details.
-func NSButton_CheckboxWithTitleTargetAction(title core.NSStringRef, target objc.Ref, action objc.Selector) NSButton {
+func NSButton_CheckboxWithTitleTargetAction(title string, target objc.Ref, action objc.Selector) NSButton {
 	ret := C.NSButton_type_CheckboxWithTitleTargetAction(
-		objc.RefPointer(title),
+		C.createNSStringFromCString(C.CString(title)),
 		objc.RefPointer(target),
 		action.SelectorAddress(),
 	)
@@ -7954,9 +7965,9 @@ func NSButton_ButtonWithImageTargetAction(image NSImageRef, target objc.Ref, act
 // NSButton_RadioButtonWithTitleTargetAction creates a standard radio button with the title you specify.
 //
 // See https://developer.apple.com/documentation/appkit/nsbutton/1644340-radiobuttonwithtitle?language=objc for details.
-func NSButton_RadioButtonWithTitleTargetAction(title core.NSStringRef, target objc.Ref, action objc.Selector) NSButton {
+func NSButton_RadioButtonWithTitleTargetAction(title string, target objc.Ref, action objc.Selector) NSButton {
 	ret := C.NSButton_type_RadioButtonWithTitleTargetAction(
-		objc.RefPointer(title),
+		C.createNSStringFromCString(C.CString(title)),
 		objc.RefPointer(target),
 		action.SelectorAddress(),
 	)
@@ -7967,9 +7978,9 @@ func NSButton_RadioButtonWithTitleTargetAction(title core.NSStringRef, target ob
 // NSButton_ButtonWithTitleImageTargetAction creates a standard push button with a title and image.
 //
 // See https://developer.apple.com/documentation/appkit/nsbutton/1644719-buttonwithtitle?language=objc for details.
-func NSButton_ButtonWithTitleImageTargetAction(title core.NSStringRef, image NSImageRef, target objc.Ref, action objc.Selector) NSButton {
+func NSButton_ButtonWithTitleImageTargetAction(title string, image NSImageRef, target objc.Ref, action objc.Selector) NSButton {
 	ret := C.NSButton_type_ButtonWithTitleImageTargetAction(
-		objc.RefPointer(title),
+		C.createNSStringFromCString(C.CString(title)),
 		objc.RefPointer(image),
 		objc.RefPointer(target),
 		action.SelectorAddress(),
@@ -7981,9 +7992,9 @@ func NSButton_ButtonWithTitleImageTargetAction(title core.NSStringRef, image NSI
 // NSButton_ButtonWithTitleTargetAction creates a standard push button with the title you specify.
 //
 // See https://developer.apple.com/documentation/appkit/nsbutton/1644256-buttonwithtitle?language=objc for details.
-func NSButton_ButtonWithTitleTargetAction(title core.NSStringRef, target objc.Ref, action objc.Selector) NSButton {
+func NSButton_ButtonWithTitleTargetAction(title string, target objc.Ref, action objc.Selector) NSButton {
 	ret := C.NSButton_type_ButtonWithTitleTargetAction(
-		objc.RefPointer(title),
+		C.createNSStringFromCString(C.CString(title)),
 		objc.RefPointer(target),
 		action.SelectorAddress(),
 	)
@@ -8086,9 +8097,9 @@ func NSFont_Alloc() NSFont {
 // NSFont_FontWithNameSize creates a font object for the specified font name and font size.
 //
 // See https://developer.apple.com/documentation/appkit/nsfont/1525977-fontwithname?language=objc for details.
-func NSFont_FontWithNameSize(fontName core.NSStringRef, fontSize core.CGFloat) NSFont {
+func NSFont_FontWithNameSize(fontName string, fontSize core.CGFloat) NSFont {
 	ret := C.NSFont_type_FontWithNameSize(
-		objc.RefPointer(fontName),
+		C.createNSStringFromCString(C.CString(fontName)),
 		C.double(fontSize),
 	)
 
@@ -8286,10 +8297,10 @@ func NSImage_Alloc() NSImage {
 // NSImage_ImageWithSystemSymbolNameAccessibilityDescription creates a symbol image with the system symbol name and accessibility description that you specify.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/3622472-imagewithsystemsymbolname?language=objc for details.
-func NSImage_ImageWithSystemSymbolNameAccessibilityDescription(symbolName core.NSStringRef, description core.NSStringRef) NSImage {
+func NSImage_ImageWithSystemSymbolNameAccessibilityDescription(symbolName string, description string) NSImage {
 	ret := C.NSImage_type_ImageWithSystemSymbolNameAccessibilityDescription(
-		objc.RefPointer(symbolName),
-		objc.RefPointer(description),
+		C.createNSStringFromCString(C.CString(symbolName)),
+		C.createNSStringFromCString(C.CString(description)),
 	)
 
 	return NSImage_FromPointer(ret)
@@ -8359,9 +8370,9 @@ func NSPasteboard_Alloc() NSPasteboard {
 // NSPasteboard_PasteboardByFilteringFile creates a new pasteboard object that supplies the specified file in as many types as possible based on the available filter services.
 //
 // See https://developer.apple.com/documentation/appkit/nspasteboard/1532744-pasteboardbyfilteringfile?language=objc for details.
-func NSPasteboard_PasteboardByFilteringFile(filename core.NSStringRef) NSPasteboard {
+func NSPasteboard_PasteboardByFilteringFile(filename string) NSPasteboard {
 	ret := C.NSPasteboard_type_PasteboardByFilteringFile(
-		objc.RefPointer(filename),
+		C.createNSStringFromCString(C.CString(filename)),
 	)
 
 	return NSPasteboard_FromPointer(ret)
@@ -8510,9 +8521,9 @@ func NSRunningApplication_Alloc() NSRunningApplication {
 // NSRunningApplication_RunningApplicationsWithBundleIdentifier returns an array of currently running applications with the specified bundle identifier.
 //
 // See https://developer.apple.com/documentation/appkit/nsrunningapplication/1530798-runningapplicationswithbundleide?language=objc for details.
-func NSRunningApplication_RunningApplicationsWithBundleIdentifier(bundleIdentifier core.NSStringRef) core.NSArray {
+func NSRunningApplication_RunningApplicationsWithBundleIdentifier(bundleIdentifier string) core.NSArray {
 	ret := C.NSRunningApplication_type_RunningApplicationsWithBundleIdentifier(
-		objc.RefPointer(bundleIdentifier),
+		C.createNSStringFromCString(C.CString(bundleIdentifier)),
 	)
 
 	return core.NSArray_FromPointer(ret)
@@ -8637,9 +8648,9 @@ func NSTextField_LabelWithAttributedString(attributedStringValue core.NSAttribut
 // NSTextField_LabelWithString initializes a text field for use as a static label that uses the system default font, doesn’t wrap, and doesn’t have selectable text.
 //
 // See https://developer.apple.com/documentation/appkit/nstextfield/1644377-labelwithstring?language=objc for details.
-func NSTextField_LabelWithString(stringValue core.NSStringRef) NSTextField {
+func NSTextField_LabelWithString(stringValue string) NSTextField {
 	ret := C.NSTextField_type_LabelWithString(
-		objc.RefPointer(stringValue),
+		C.createNSStringFromCString(C.CString(stringValue)),
 	)
 
 	return NSTextField_FromPointer(ret)
@@ -8648,9 +8659,9 @@ func NSTextField_LabelWithString(stringValue core.NSStringRef) NSTextField {
 // NSTextField_TextFieldWithString initializes a single-line editable text field for user input using the system default font and standard visual appearance.
 //
 // See https://developer.apple.com/documentation/appkit/nstextfield/1644706-textfieldwithstring?language=objc for details.
-func NSTextField_TextFieldWithString(stringValue core.NSStringRef) NSTextField {
+func NSTextField_TextFieldWithString(stringValue string) NSTextField {
 	ret := C.NSTextField_type_TextFieldWithString(
-		objc.RefPointer(stringValue),
+		C.createNSStringFromCString(C.CString(stringValue)),
 	)
 
 	return NSTextField_FromPointer(ret)
@@ -8659,9 +8670,9 @@ func NSTextField_TextFieldWithString(stringValue core.NSStringRef) NSTextField {
 // NSTextField_WrappingLabelWithString initializes a text field for use as a multiline static label with selectable text that uses the system default font.
 //
 // See https://developer.apple.com/documentation/appkit/nstextfield/1644543-wrappinglabelwithstring?language=objc for details.
-func NSTextField_WrappingLabelWithString(stringValue core.NSStringRef) NSTextField {
+func NSTextField_WrappingLabelWithString(stringValue string) NSTextField {
 	ret := C.NSTextField_type_WrappingLabelWithString(
-		objc.RefPointer(stringValue),
+		C.createNSStringFromCString(C.CString(stringValue)),
 	)
 
 	return NSTextField_FromPointer(ret)
@@ -8733,9 +8744,9 @@ func NSWindow_FrameRectForContentRectStyleMask(cRect core.NSRect, style core.NSU
 // NSWindow_MinFrameWidthWithTitleStyleMask returns the minimum width a window’s frame rectangle must have for it to display a title, with a given window style.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/1419294-minframewidthwithtitle?language=objc for details.
-func NSWindow_MinFrameWidthWithTitleStyleMask(title core.NSStringRef, style core.NSUInteger) core.CGFloat {
+func NSWindow_MinFrameWidthWithTitleStyleMask(title string, style core.NSUInteger) core.CGFloat {
 	ret := C.NSWindow_type_MinFrameWidthWithTitleStyleMask(
-		objc.RefPointer(title),
+		C.createNSStringFromCString(C.CString(title)),
 		C.ulong(style),
 	)
 
@@ -9002,11 +9013,11 @@ func NSBundle_FromRef(ref objc.Ref) NSBundle {
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1411412-urlforauxiliaryexecutable?language=objc for details.
 func (x gen_NSBundle) URLForAuxiliaryExecutable(
-	executableName core.NSStringRef,
+	executableName string,
 ) core.NSURL {
 	ret := C.NSBundle_inst_URLForAuxiliaryExecutable(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(executableName),
+		C.createNSStringFromCString(C.CString(executableName)),
 	)
 
 	return core.NSURL_FromPointer(ret)
@@ -9016,13 +9027,13 @@ func (x gen_NSBundle) URLForAuxiliaryExecutable(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1411540-urlforresource?language=objc for details.
 func (x gen_NSBundle) URLForResourceWithExtension(
-	name core.NSStringRef,
-	ext core.NSStringRef,
+	name string,
+	ext string,
 ) core.NSURL {
 	ret := C.NSBundle_inst_URLForResourceWithExtension(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(name),
-		objc.RefPointer(ext),
+		C.createNSStringFromCString(C.CString(name)),
+		C.createNSStringFromCString(C.CString(ext)),
 	)
 
 	return core.NSURL_FromPointer(ret)
@@ -9032,15 +9043,15 @@ func (x gen_NSBundle) URLForResourceWithExtension(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1416712-urlforresource?language=objc for details.
 func (x gen_NSBundle) URLForResourceWithExtensionSubdirectory(
-	name core.NSStringRef,
-	ext core.NSStringRef,
-	subpath core.NSStringRef,
+	name string,
+	ext string,
+	subpath string,
 ) core.NSURL {
 	ret := C.NSBundle_inst_URLForResourceWithExtensionSubdirectory(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(name),
-		objc.RefPointer(ext),
-		objc.RefPointer(subpath),
+		C.createNSStringFromCString(C.CString(name)),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(subpath)),
 	)
 
 	return core.NSURL_FromPointer(ret)
@@ -9050,17 +9061,17 @@ func (x gen_NSBundle) URLForResourceWithExtensionSubdirectory(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1417378-urlforresource?language=objc for details.
 func (x gen_NSBundle) URLForResourceWithExtensionSubdirectoryLocalization(
-	name core.NSStringRef,
-	ext core.NSStringRef,
-	subpath core.NSStringRef,
-	localizationName core.NSStringRef,
+	name string,
+	ext string,
+	subpath string,
+	localizationName string,
 ) core.NSURL {
 	ret := C.NSBundle_inst_URLForResourceWithExtensionSubdirectoryLocalization(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(name),
-		objc.RefPointer(ext),
-		objc.RefPointer(subpath),
-		objc.RefPointer(localizationName),
+		C.createNSStringFromCString(C.CString(name)),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(subpath)),
+		C.createNSStringFromCString(C.CString(localizationName)),
 	)
 
 	return core.NSURL_FromPointer(ret)
@@ -9070,13 +9081,13 @@ func (x gen_NSBundle) URLForResourceWithExtensionSubdirectoryLocalization(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1407424-urlsforresourceswithextension?language=objc for details.
 func (x gen_NSBundle) URLsForResourcesWithExtensionSubdirectory(
-	ext core.NSStringRef,
-	subpath core.NSStringRef,
+	ext string,
+	subpath string,
 ) core.NSArray {
 	ret := C.NSBundle_inst_URLsForResourcesWithExtensionSubdirectory(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(ext),
-		objc.RefPointer(subpath),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(subpath)),
 	)
 
 	return core.NSArray_FromPointer(ret)
@@ -9086,15 +9097,15 @@ func (x gen_NSBundle) URLsForResourcesWithExtensionSubdirectory(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1414688-urlsforresourceswithextension?language=objc for details.
 func (x gen_NSBundle) URLsForResourcesWithExtensionSubdirectoryLocalization(
-	ext core.NSStringRef,
-	subpath core.NSStringRef,
-	localizationName core.NSStringRef,
+	ext string,
+	subpath string,
+	localizationName string,
 ) core.NSArray {
 	ret := C.NSBundle_inst_URLsForResourcesWithExtensionSubdirectoryLocalization(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(ext),
-		objc.RefPointer(subpath),
-		objc.RefPointer(localizationName),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(subpath)),
+		C.createNSStringFromCString(C.CString(localizationName)),
 	)
 
 	return core.NSArray_FromPointer(ret)
@@ -9104,11 +9115,11 @@ func (x gen_NSBundle) URLsForResourcesWithExtensionSubdirectoryLocalization(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1412741-initwithpath?language=objc for details.
 func (x gen_NSBundle) InitWithPath(
-	path core.NSStringRef,
+	path string,
 ) NSBundle {
 	ret := C.NSBundle_inst_InitWithPath(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 	)
 
 	return NSBundle_FromPointer(ret)
@@ -9157,13 +9168,13 @@ func (x gen_NSBundle) LoadAndReturnError(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1618147-loadnibnamed?language=objc for details.
 func (x gen_NSBundle) LoadNibNamedOwnerOptions(
-	name core.NSStringRef,
+	name string,
 	owner objc.Ref,
 	options core.NSDictionaryRef,
 ) core.NSArray {
 	ret := C.NSBundle_inst_LoadNibNamedOwnerOptions(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(name),
+		C.createNSStringFromCString(C.CString(name)),
 		objc.RefPointer(owner),
 		objc.RefPointer(options),
 	)
@@ -9175,15 +9186,15 @@ func (x gen_NSBundle) LoadNibNamedOwnerOptions(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/3746904-localizedattributedstringforkey?language=objc for details.
 func (x gen_NSBundle) LocalizedAttributedStringForKeyValueTable(
-	key core.NSStringRef,
-	value core.NSStringRef,
-	tableName core.NSStringRef,
+	key string,
+	value string,
+	tableName string,
 ) core.NSAttributedString {
 	ret := C.NSBundle_inst_LocalizedAttributedStringForKeyValueTable(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(key),
-		objc.RefPointer(value),
-		objc.RefPointer(tableName),
+		C.createNSStringFromCString(C.CString(key)),
+		C.createNSStringFromCString(C.CString(value)),
+		C.createNSStringFromCString(C.CString(tableName)),
 	)
 
 	return core.NSAttributedString_FromPointer(ret)
@@ -9193,29 +9204,29 @@ func (x gen_NSBundle) LocalizedAttributedStringForKeyValueTable(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1417694-localizedstringforkey?language=objc for details.
 func (x gen_NSBundle) LocalizedStringForKeyValueTable(
-	key core.NSStringRef,
-	value core.NSStringRef,
-	tableName core.NSStringRef,
-) core.NSString {
+	key string,
+	value string,
+	tableName string,
+) string {
 	ret := C.NSBundle_inst_LocalizedStringForKeyValueTable(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(key),
-		objc.RefPointer(value),
-		objc.RefPointer(tableName),
+		C.createNSStringFromCString(C.CString(key)),
+		C.createNSStringFromCString(C.CString(value)),
+		C.createNSStringFromCString(C.CString(tableName)),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // ObjectForInfoDictionaryKey returns the value associated with the specified key in the receiver's information property list.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1408696-objectforinfodictionarykey?language=objc for details.
 func (x gen_NSBundle) ObjectForInfoDictionaryKey(
-	key core.NSStringRef,
+	key string,
 ) objc.Object {
 	ret := C.NSBundle_inst_ObjectForInfoDictionaryKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 	)
 
 	return objc.Object_FromPointer(ret)
@@ -9225,81 +9236,81 @@ func (x gen_NSBundle) ObjectForInfoDictionaryKey(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1415214-pathforauxiliaryexecutable?language=objc for details.
 func (x gen_NSBundle) PathForAuxiliaryExecutable(
-	executableName core.NSStringRef,
-) core.NSString {
+	executableName string,
+) string {
 	ret := C.NSBundle_inst_PathForAuxiliaryExecutable(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(executableName),
+		C.createNSStringFromCString(C.CString(executableName)),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // PathForResourceOfType returns the full pathname for the resource identified by the specified name and file extension.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1410989-pathforresource?language=objc for details.
 func (x gen_NSBundle) PathForResourceOfType(
-	name core.NSStringRef,
-	ext core.NSStringRef,
-) core.NSString {
+	name string,
+	ext string,
+) string {
 	ret := C.NSBundle_inst_PathForResourceOfType(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(name),
-		objc.RefPointer(ext),
+		C.createNSStringFromCString(C.CString(name)),
+		C.createNSStringFromCString(C.CString(ext)),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // PathForResourceOfTypeInDirectory returns the full pathname for the resource identified by the specified name and file extension and located in the specified bundle subdirectory.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1409670-pathforresource?language=objc for details.
 func (x gen_NSBundle) PathForResourceOfTypeInDirectory(
-	name core.NSStringRef,
-	ext core.NSStringRef,
-	subpath core.NSStringRef,
-) core.NSString {
+	name string,
+	ext string,
+	subpath string,
+) string {
 	ret := C.NSBundle_inst_PathForResourceOfTypeInDirectory(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(name),
-		objc.RefPointer(ext),
-		objc.RefPointer(subpath),
+		C.createNSStringFromCString(C.CString(name)),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(subpath)),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // PathForResourceOfTypeInDirectoryForLocalization returns the full pathname for the resource identified by the specified name and file extension, located in the specified bundle subdirectory, and limited to global resources and those associated with the specified localization.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1413471-pathforresource?language=objc for details.
 func (x gen_NSBundle) PathForResourceOfTypeInDirectoryForLocalization(
-	name core.NSStringRef,
-	ext core.NSStringRef,
-	subpath core.NSStringRef,
-	localizationName core.NSStringRef,
-) core.NSString {
+	name string,
+	ext string,
+	subpath string,
+	localizationName string,
+) string {
 	ret := C.NSBundle_inst_PathForResourceOfTypeInDirectoryForLocalization(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(name),
-		objc.RefPointer(ext),
-		objc.RefPointer(subpath),
-		objc.RefPointer(localizationName),
+		C.createNSStringFromCString(C.CString(name)),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(subpath)),
+		C.createNSStringFromCString(C.CString(localizationName)),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // PathsForResourcesOfTypeInDirectory returns an array containing the pathnames for all bundle resources having the specified filename extension and residing in the resource subdirectory.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1413058-pathsforresourcesoftype?language=objc for details.
 func (x gen_NSBundle) PathsForResourcesOfTypeInDirectory(
-	ext core.NSStringRef,
-	subpath core.NSStringRef,
+	ext string,
+	subpath string,
 ) core.NSArray {
 	ret := C.NSBundle_inst_PathsForResourcesOfTypeInDirectory(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(ext),
-		objc.RefPointer(subpath),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(subpath)),
 	)
 
 	return core.NSArray_FromPointer(ret)
@@ -9309,15 +9320,15 @@ func (x gen_NSBundle) PathsForResourcesOfTypeInDirectory(
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1416940-pathsforresourcesoftype?language=objc for details.
 func (x gen_NSBundle) PathsForResourcesOfTypeInDirectoryForLocalization(
-	ext core.NSStringRef,
-	subpath core.NSStringRef,
-	localizationName core.NSStringRef,
+	ext string,
+	subpath string,
+	localizationName string,
 ) core.NSArray {
 	ret := C.NSBundle_inst_PathsForResourcesOfTypeInDirectoryForLocalization(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(ext),
-		objc.RefPointer(subpath),
-		objc.RefPointer(localizationName),
+		C.createNSStringFromCString(C.CString(ext)),
+		C.createNSStringFromCString(C.CString(subpath)),
+		C.createNSStringFromCString(C.CString(localizationName)),
 	)
 
 	return core.NSArray_FromPointer(ret)
@@ -9446,67 +9457,67 @@ func (x gen_NSBundle) AppStoreReceiptURL() core.NSURL {
 // ResourcePath returns the full pathname of the bundle’s subdirectory containing resources.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1417723-resourcepath?language=objc for details.
-func (x gen_NSBundle) ResourcePath() core.NSString {
+func (x gen_NSBundle) ResourcePath() string {
 	ret := C.NSBundle_inst_ResourcePath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // ExecutablePath returns the full pathname of the receiver's executable file.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1409078-executablepath?language=objc for details.
-func (x gen_NSBundle) ExecutablePath() core.NSString {
+func (x gen_NSBundle) ExecutablePath() string {
 	ret := C.NSBundle_inst_ExecutablePath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // PrivateFrameworksPath returns the full pathname of the bundle’s subdirectory containing private frameworks.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1415562-privateframeworkspath?language=objc for details.
-func (x gen_NSBundle) PrivateFrameworksPath() core.NSString {
+func (x gen_NSBundle) PrivateFrameworksPath() string {
 	ret := C.NSBundle_inst_PrivateFrameworksPath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SharedFrameworksPath returns the full pathname of the bundle’s subdirectory containing shared frameworks.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1417226-sharedframeworkspath?language=objc for details.
-func (x gen_NSBundle) SharedFrameworksPath() core.NSString {
+func (x gen_NSBundle) SharedFrameworksPath() string {
 	ret := C.NSBundle_inst_SharedFrameworksPath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // BuiltInPlugInsPath returns the full pathname of the receiver's subdirectory containing plug-ins.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1408900-builtinpluginspath?language=objc for details.
-func (x gen_NSBundle) BuiltInPlugInsPath() core.NSString {
+func (x gen_NSBundle) BuiltInPlugInsPath() string {
 	ret := C.NSBundle_inst_BuiltInPlugInsPath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SharedSupportPath returns the full pathname of the bundle’s subdirectory containing shared support files.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1411609-sharedsupportpath?language=objc for details.
-func (x gen_NSBundle) SharedSupportPath() core.NSString {
+func (x gen_NSBundle) SharedSupportPath() string {
 	ret := C.NSBundle_inst_SharedSupportPath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // BundleURL returns the full URL of the receiver’s bundle directory.
@@ -9523,23 +9534,23 @@ func (x gen_NSBundle) BundleURL() core.NSURL {
 // BundlePath returns the full pathname of the receiver’s bundle directory.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1407973-bundlepath?language=objc for details.
-func (x gen_NSBundle) BundlePath() core.NSString {
+func (x gen_NSBundle) BundlePath() string {
 	ret := C.NSBundle_inst_BundlePath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // BundleIdentifier returns the receiver’s bundle identifier.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1418023-bundleidentifier?language=objc for details.
-func (x gen_NSBundle) BundleIdentifier() core.NSString {
+func (x gen_NSBundle) BundleIdentifier() string {
 	ret := C.NSBundle_inst_BundleIdentifier(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // InfoDictionary returns a dictionary, constructed from the bundle’s Info.plist file, that contains information about the receiver.
@@ -9578,12 +9589,12 @@ func (x gen_NSBundle) PreferredLocalizations() core.NSArray {
 // DevelopmentLocalization returns the localization for the development language.
 //
 // See https://developer.apple.com/documentation/foundation/nsbundle/1417526-developmentlocalization?language=objc for details.
-func (x gen_NSBundle) DevelopmentLocalization() core.NSString {
+func (x gen_NSBundle) DevelopmentLocalization() string {
 	ret := C.NSBundle_inst_DevelopmentLocalization(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // LocalizedInfoDictionary returns a dictionary with the keys from the bundle’s localized property list.
@@ -9642,12 +9653,12 @@ func NSSound_FromRef(ref objc.Ref) NSSound {
 //
 // See https://developer.apple.com/documentation/appkit/nssound/1477274-initwithcontentsoffile?language=objc for details.
 func (x gen_NSSound) InitWithContentsOfFileByReference(
-	path core.NSStringRef,
+	path string,
 	byRef bool,
 ) NSSound {
 	ret := C.NSSound_inst_InitWithContentsOfFileByReference(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		convertToObjCBool(byRef),
 	)
 
@@ -10866,23 +10877,23 @@ func (x gen_NSControl) SetObjectValue(
 // StringValue returns the value of the receiver’s cell as an NSString object.
 //
 // See https://developer.apple.com/documentation/appkit/nscontrol/1428950-stringvalue?language=objc for details.
-func (x gen_NSControl) StringValue() core.NSString {
+func (x gen_NSControl) StringValue() string {
 	ret := C.NSControl_inst_StringValue(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetStringValue returns the value of the receiver’s cell as an NSString object.
 //
 // See https://developer.apple.com/documentation/appkit/nscontrol/1428950-stringvalue?language=objc for details.
 func (x gen_NSControl) SetStringValue(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSControl_inst_SetStringValue(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -11320,23 +11331,23 @@ func (x gen_NSButton) SetHasDestructiveAction(
 // AlternateTitle returns the title that the button displays when the button is in an on state.
 //
 // See https://developer.apple.com/documentation/appkit/nsbutton/1529588-alternatetitle?language=objc for details.
-func (x gen_NSButton) AlternateTitle() core.NSString {
+func (x gen_NSButton) AlternateTitle() string {
 	ret := C.NSButton_inst_AlternateTitle(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetAlternateTitle returns the title that the button displays when the button is in an on state.
 //
 // See https://developer.apple.com/documentation/appkit/nsbutton/1529588-alternatetitle?language=objc for details.
 func (x gen_NSButton) SetAlternateTitle(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSButton_inst_SetAlternateTitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -11395,23 +11406,23 @@ func (x gen_NSButton) SetAttributedAlternateTitle(
 // Title returns the title displayed on the button when it’s in an off state.
 //
 // See https://developer.apple.com/documentation/appkit/nsbutton/1524430-title?language=objc for details.
-func (x gen_NSButton) Title() core.NSString {
+func (x gen_NSButton) Title() string {
 	ret := C.NSButton_inst_Title(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetTitle returns the title displayed on the button when it’s in an off state.
 //
 // See https://developer.apple.com/documentation/appkit/nsbutton/1524430-title?language=objc for details.
 func (x gen_NSButton) SetTitle(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSButton_inst_SetTitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -11720,23 +11731,23 @@ func (x gen_NSButton) SetState(
 // KeyEquivalent returns the key-equivalent character of the button.
 //
 // See https://developer.apple.com/documentation/appkit/nsbutton/1525368-keyequivalent?language=objc for details.
-func (x gen_NSButton) KeyEquivalent() core.NSString {
+func (x gen_NSButton) KeyEquivalent() string {
 	ret := C.NSButton_inst_KeyEquivalent(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetKeyEquivalent returns the key-equivalent character of the button.
 //
 // See https://developer.apple.com/documentation/appkit/nsbutton/1525368-keyequivalent?language=objc for details.
 func (x gen_NSButton) SetKeyEquivalent(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSButton_inst_SetKeyEquivalent(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -11826,23 +11837,23 @@ func (x gen_NSEvent) EventRef() unsafe.Pointer {
 // Characters returns the characters associated with a key-up or key-down event.
 //
 // See https://developer.apple.com/documentation/appkit/nsevent/1534183-characters?language=objc for details.
-func (x gen_NSEvent) Characters() core.NSString {
+func (x gen_NSEvent) Characters() string {
 	ret := C.NSEvent_inst_Characters(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // CharactersIgnoringModifiers returns the characters generated by a key event as if no modifier key (except for Shift) applies.
 //
 // See https://developer.apple.com/documentation/appkit/nsevent/1524605-charactersignoringmodifiers?language=objc for details.
-func (x gen_NSEvent) CharactersIgnoringModifiers() core.NSString {
+func (x gen_NSEvent) CharactersIgnoringModifiers() string {
 	ret := C.NSEvent_inst_CharactersIgnoringModifiers(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // IsARepeat returns a Boolean value that indicates whether the key event is a repeat.
@@ -12306,34 +12317,34 @@ func (x gen_NSFont) NumberOfGlyphs() core.NSUInteger {
 // DisplayName returns the name of the font, including family and face names, to use when displaying the font information to the user.
 //
 // See https://developer.apple.com/documentation/appkit/nsfont/1531660-displayname?language=objc for details.
-func (x gen_NSFont) DisplayName() core.NSString {
+func (x gen_NSFont) DisplayName() string {
 	ret := C.NSFont_inst_DisplayName(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // FamilyName returns the family name of the font—for example, “Times” or “Helvetica.”
 //
 // See https://developer.apple.com/documentation/appkit/nsfont/1529585-familyname?language=objc for details.
-func (x gen_NSFont) FamilyName() core.NSString {
+func (x gen_NSFont) FamilyName() string {
 	ret := C.NSFont_inst_FamilyName(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // FontName returns the full name of the font, as used in PostScript language code—for example, “Times-Roman” or “Helvetica-Oblique.”
 //
 // See https://developer.apple.com/documentation/appkit/nsfont/1526183-fontname?language=objc for details.
-func (x gen_NSFont) FontName() core.NSString {
+func (x gen_NSFont) FontName() string {
 	ret := C.NSFont_inst_FontName(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // IsVertical returns a Boolean value indicating whether the font is a vertical font.
@@ -12420,11 +12431,11 @@ func (x gen_NSImage) DrawInRect(
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519955-initbyreferencingfile?language=objc for details.
 func (x gen_NSImage) InitByReferencingFile(
-	fileName core.NSStringRef,
+	fileName string,
 ) NSImage {
 	ret := C.NSImage_inst_InitByReferencingFile(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(fileName),
+		C.createNSStringFromCString(C.CString(fileName)),
 	)
 
 	return NSImage_FromPointer(ret)
@@ -12448,11 +12459,11 @@ func (x gen_NSImage) InitByReferencingURL(
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519918-initwithcontentsoffile?language=objc for details.
 func (x gen_NSImage) InitWithContentsOfFile(
-	fileName core.NSStringRef,
+	fileName string,
 ) NSImage {
 	ret := C.NSImage_inst_InitWithContentsOfFile(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(fileName),
+		C.createNSStringFromCString(C.CString(fileName)),
 	)
 
 	return NSImage_FromPointer(ret)
@@ -12857,23 +12868,23 @@ func (x gen_NSImage) TIFFRepresentation() core.NSData {
 // AccessibilityDescription returns the image’s accessibility description.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519943-accessibilitydescription?language=objc for details.
-func (x gen_NSImage) AccessibilityDescription() core.NSString {
+func (x gen_NSImage) AccessibilityDescription() string {
 	ret := C.NSImage_inst_AccessibilityDescription(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetAccessibilityDescription returns the image’s accessibility description.
 //
 // See https://developer.apple.com/documentation/appkit/nsimage/1519943-accessibilitydescription?language=objc for details.
 func (x gen_NSImage) SetAccessibilityDescription(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSImage_inst_SetAccessibilityDescription(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -13258,11 +13269,11 @@ func (x gen_NSPasteboard) ReleaseGlobally() {
 //
 // See https://developer.apple.com/documentation/appkit/nspasteboard/1531224-writefilecontents?language=objc for details.
 func (x gen_NSPasteboard) WriteFileContents(
-	filename core.NSStringRef,
+	filename string,
 ) bool {
 	ret := C.NSPasteboard_inst_WriteFileContents(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(filename),
+		C.createNSStringFromCString(C.CString(filename)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -14013,15 +14024,15 @@ func (x gen_NSMenu) AddItem(
 //
 // See https://developer.apple.com/documentation/appkit/nsmenu/1518181-additemwithtitle?language=objc for details.
 func (x gen_NSMenu) AddItemWithTitleActionKeyEquivalent(
-	string core.NSStringRef,
+	string string,
 	selector objc.Selector,
-	charCode core.NSStringRef,
+	charCode string,
 ) NSMenuItem {
 	ret := C.NSMenu_inst_AddItemWithTitleActionKeyEquivalent(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(string),
+		C.createNSStringFromCString(C.CString(string)),
 		selector.SelectorAddress(),
-		objc.RefPointer(charCode),
+		C.createNSStringFromCString(C.CString(charCode)),
 	)
 
 	return NSMenuItem_FromPointer(ret)
@@ -14125,11 +14136,11 @@ func (x gen_NSMenu) IndexOfItemWithTargetAndAction(
 //
 // See https://developer.apple.com/documentation/appkit/nsmenu/1518237-indexofitemwithtitle?language=objc for details.
 func (x gen_NSMenu) IndexOfItemWithTitle(
-	title core.NSStringRef,
+	title string,
 ) core.NSInteger {
 	ret := C.NSMenu_inst_IndexOfItemWithTitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(title),
+		C.createNSStringFromCString(C.CString(title)),
 	)
 
 	return core.NSInteger(ret)
@@ -14139,11 +14150,11 @@ func (x gen_NSMenu) IndexOfItemWithTitle(
 //
 // See https://developer.apple.com/documentation/appkit/nsmenu/1518144-initwithtitle?language=objc for details.
 func (x gen_NSMenu) InitWithTitle(
-	title core.NSStringRef,
+	title string,
 ) NSMenu {
 	ret := C.NSMenu_inst_InitWithTitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(title),
+		C.createNSStringFromCString(C.CString(title)),
 	)
 
 	return NSMenu_FromPointer(ret)
@@ -14169,16 +14180,16 @@ func (x gen_NSMenu) InsertItemAtIndex(
 //
 // See https://developer.apple.com/documentation/appkit/nsmenu/1518146-insertitemwithtitle?language=objc for details.
 func (x gen_NSMenu) InsertItemWithTitleActionKeyEquivalentAtIndex(
-	string core.NSStringRef,
+	string string,
 	selector objc.Selector,
-	charCode core.NSStringRef,
+	charCode string,
 	index core.NSInteger,
 ) NSMenuItem {
 	ret := C.NSMenu_inst_InsertItemWithTitleActionKeyEquivalentAtIndex(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(string),
+		C.createNSStringFromCString(C.CString(string)),
 		selector.SelectorAddress(),
-		objc.RefPointer(charCode),
+		C.createNSStringFromCString(C.CString(charCode)),
 		C.long(index),
 	)
 
@@ -14231,11 +14242,11 @@ func (x gen_NSMenu) ItemWithTag(
 //
 // See https://developer.apple.com/documentation/appkit/nsmenu/1518248-itemwithtitle?language=objc for details.
 func (x gen_NSMenu) ItemWithTitle(
-	title core.NSStringRef,
+	title string,
 ) NSMenuItem {
 	ret := C.NSMenu_inst_ItemWithTitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(title),
+		C.createNSStringFromCString(C.CString(title)),
 	)
 
 	return NSMenuItem_FromPointer(ret)
@@ -14510,23 +14521,23 @@ func (x gen_NSMenu) SetFont(
 // Title returns the title of the menu.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenu/1518192-title?language=objc for details.
-func (x gen_NSMenu) Title() core.NSString {
+func (x gen_NSMenu) Title() string {
 	ret := C.NSMenu_inst_Title(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetTitle returns the title of the menu.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenu/1518192-title?language=objc for details.
 func (x gen_NSMenu) SetTitle(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSMenu_inst_SetTitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -14865,15 +14876,15 @@ func NSMenuItem_FromRef(ref objc.Ref) NSMenuItem {
 //
 // See https://developer.apple.com/documentation/appkit/nsmenuitem/1514858-initwithtitle?language=objc for details.
 func (x gen_NSMenuItem) InitWithTitleActionKeyEquivalent(
-	string core.NSStringRef,
+	string string,
 	selector objc.Selector,
-	charCode core.NSStringRef,
+	charCode string,
 ) NSMenuItem {
 	ret := C.NSMenuItem_inst_InitWithTitleActionKeyEquivalent(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(string),
+		C.createNSStringFromCString(C.CString(string)),
 		selector.SelectorAddress(),
-		objc.RefPointer(charCode),
+		C.createNSStringFromCString(C.CString(charCode)),
 	)
 
 	return NSMenuItem_FromPointer(ret)
@@ -15011,23 +15022,23 @@ func (x gen_NSMenuItem) SetAction(
 // Title returns the menu item's title.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenuitem/1514805-title?language=objc for details.
-func (x gen_NSMenuItem) Title() core.NSString {
+func (x gen_NSMenuItem) Title() string {
 	ret := C.NSMenuItem_inst_Title(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetTitle returns the menu item's title.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenuitem/1514805-title?language=objc for details.
 func (x gen_NSMenuItem) SetTitle(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSMenuItem_inst_SetTitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -15294,23 +15305,23 @@ func (x gen_NSMenuItem) SetMenu(
 // KeyEquivalent returns the menu item’s unmodified key equivalent.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenuitem/1514842-keyequivalent?language=objc for details.
-func (x gen_NSMenuItem) KeyEquivalent() core.NSString {
+func (x gen_NSMenuItem) KeyEquivalent() string {
 	ret := C.NSMenuItem_inst_KeyEquivalent(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetKeyEquivalent returns the menu item’s unmodified key equivalent.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenuitem/1514842-keyequivalent?language=objc for details.
 func (x gen_NSMenuItem) SetKeyEquivalent(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSMenuItem_inst_SetKeyEquivalent(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -15319,12 +15330,12 @@ func (x gen_NSMenuItem) SetKeyEquivalent(
 // UserKeyEquivalent returns the user-assigned key equivalent for the menu item.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenuitem/1514850-userkeyequivalent?language=objc for details.
-func (x gen_NSMenuItem) UserKeyEquivalent() core.NSString {
+func (x gen_NSMenuItem) UserKeyEquivalent() string {
 	ret := C.NSMenuItem_inst_UserKeyEquivalent(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // IsAlternate returns a Boolean value that marks the menu item as an alternate to the previous menu item.
@@ -15380,23 +15391,23 @@ func (x gen_NSMenuItem) SetIndentationLevel(
 // ToolTip returns a help tag for the menu item.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenuitem/1514848-tooltip?language=objc for details.
-func (x gen_NSMenuItem) ToolTip() core.NSString {
+func (x gen_NSMenuItem) ToolTip() string {
 	ret := C.NSMenuItem_inst_ToolTip(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetToolTip returns a help tag for the menu item.
 //
 // See https://developer.apple.com/documentation/appkit/nsmenuitem/1514848-tooltip?language=objc for details.
 func (x gen_NSMenuItem) SetToolTip(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSMenuItem_inst_SetToolTip(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -15655,12 +15666,12 @@ func (x gen_NSRunningApplication) IsHidden() bool {
 // LocalizedName indicates the localized name of the application.
 //
 // See https://developer.apple.com/documentation/appkit/nsrunningapplication/1526751-localizedname?language=objc for details.
-func (x gen_NSRunningApplication) LocalizedName() core.NSString {
+func (x gen_NSRunningApplication) LocalizedName() string {
 	ret := C.NSRunningApplication_inst_LocalizedName(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Icon returns the icon for the receiver’s application.
@@ -15677,12 +15688,12 @@ func (x gen_NSRunningApplication) Icon() NSImage {
 // BundleIdentifier indicates the CFBundleIdentifier of the application.
 //
 // See https://developer.apple.com/documentation/appkit/nsrunningapplication/1529140-bundleidentifier?language=objc for details.
-func (x gen_NSRunningApplication) BundleIdentifier() core.NSString {
+func (x gen_NSRunningApplication) BundleIdentifier() string {
 	ret := C.NSRunningApplication_inst_BundleIdentifier(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // BundleURL indicates the URL to the application's bundle.
@@ -15896,12 +15907,12 @@ func (x gen_NSScreen) MaximumReferenceExtendedDynamicRangeColorComponentValue() 
 // LocalizedName is undocumented.
 //
 // See https://developer.apple.com/documentation/appkit/nsscreen/3228043-localizedname?language=objc for details.
-func (x gen_NSScreen) LocalizedName() core.NSString {
+func (x gen_NSScreen) LocalizedName() string {
 	ret := C.NSScreen_inst_LocalizedName(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // MaximumFramesPerSecond is undocumented.
@@ -16417,11 +16428,11 @@ func (x gen_NSText) PasteRuler(
 //
 // See https://developer.apple.com/documentation/appkit/nstext/1532564-readrtfdfromfile?language=objc for details.
 func (x gen_NSText) ReadRTFDFromFile(
-	path core.NSStringRef,
+	path string,
 ) bool {
 	ret := C.NSText_inst_ReadRTFDFromFile(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -16540,12 +16551,12 @@ func (x gen_NSText) Unscript(
 //
 // See https://developer.apple.com/documentation/appkit/nstext/1527085-writertfdtofile?language=objc for details.
 func (x gen_NSText) WriteRTFDToFileAtomically(
-	path core.NSStringRef,
+	path string,
 	flag bool,
 ) bool {
 	ret := C.NSText_inst_WriteRTFDToFileAtomically(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		convertToObjCBool(flag),
 	)
 
@@ -16573,23 +16584,23 @@ func (x gen_NSText) Init_AsNSText() NSText {
 // String returns the characters of the receiver’s text.
 //
 // See https://developer.apple.com/documentation/appkit/nstext/1528601-string?language=objc for details.
-func (x gen_NSText) String() core.NSString {
+func (x gen_NSText) String() string {
 	ret := C.NSText_inst_String(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetString returns the characters of the receiver’s text.
 //
 // See https://developer.apple.com/documentation/appkit/nstext/1528601-string?language=objc for details.
 func (x gen_NSText) SetString(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSText_inst_SetString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -17163,23 +17174,23 @@ func (x gen_NSTextField) SetImportsGraphics(
 // PlaceholderString returns the string the text field displays when empty to help the user understand the text field’s purpose.
 //
 // See https://developer.apple.com/documentation/appkit/nstextfield/1399391-placeholderstring?language=objc for details.
-func (x gen_NSTextField) PlaceholderString() core.NSString {
+func (x gen_NSTextField) PlaceholderString() string {
 	ret := C.NSTextField_inst_PlaceholderString(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetPlaceholderString returns the string the text field displays when empty to help the user understand the text field’s purpose.
 //
 // See https://developer.apple.com/documentation/appkit/nstextfield/1399391-placeholderstring?language=objc for details.
 func (x gen_NSTextField) SetPlaceholderString(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSTextField_inst_SetPlaceholderString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -18167,23 +18178,23 @@ func (x gen_NSViewController) SetView(
 // Title returns the localized title of the receiver’s primary view.
 //
 // See https://developer.apple.com/documentation/appkit/nsviewcontroller/1434426-title?language=objc for details.
-func (x gen_NSViewController) Title() core.NSString {
+func (x gen_NSViewController) Title() string {
 	ret := C.NSViewController_inst_Title(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetTitle returns the localized title of the receiver’s primary view.
 //
 // See https://developer.apple.com/documentation/appkit/nsviewcontroller/1434426-title?language=objc for details.
 func (x gen_NSViewController) SetTitle(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSViewController_inst_SetTitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -19599,11 +19610,11 @@ func (x gen_NSWindow) SetIsZoomed(
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/1419192-settitlewithrepresentedfilename?language=objc for details.
 func (x gen_NSWindow) SetTitleWithRepresentedFilename(
-	filename core.NSStringRef,
+	filename string,
 ) {
 	C.NSWindow_inst_SetTitleWithRepresentedFilename(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(filename),
+		C.createNSStringFromCString(C.CString(filename)),
 	)
 
 	return
@@ -21063,23 +21074,23 @@ func (x gen_NSWindow) BackingScaleFactor() core.CGFloat {
 // Title returns the string that appears in the title bar of the window or the path to the represented file.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/1419404-title?language=objc for details.
-func (x gen_NSWindow) Title() core.NSString {
+func (x gen_NSWindow) Title() string {
 	ret := C.NSWindow_inst_Title(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetTitle returns the string that appears in the title bar of the window or the path to the represented file.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/1419404-title?language=objc for details.
 func (x gen_NSWindow) SetTitle(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSWindow_inst_SetTitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -21088,23 +21099,23 @@ func (x gen_NSWindow) SetTitle(
 // Subtitle returns a secondary line of text that appears in the title bar of the window.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/3608198-subtitle?language=objc for details.
-func (x gen_NSWindow) Subtitle() core.NSString {
+func (x gen_NSWindow) Subtitle() string {
 	ret := C.NSWindow_inst_Subtitle(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetSubtitle returns a secondary line of text that appears in the title bar of the window.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/3608198-subtitle?language=objc for details.
 func (x gen_NSWindow) SetSubtitle(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSWindow_inst_SetSubtitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -21138,23 +21149,23 @@ func (x gen_NSWindow) SetTitleVisibility(
 // RepresentedFilename returns the path to the file of the window’s represented file.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/1419631-representedfilename?language=objc for details.
-func (x gen_NSWindow) RepresentedFilename() core.NSString {
+func (x gen_NSWindow) RepresentedFilename() string {
 	ret := C.NSWindow_inst_RepresentedFilename(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetRepresentedFilename returns the path to the file of the window’s represented file.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/1419631-representedfilename?language=objc for details.
 func (x gen_NSWindow) SetRepresentedFilename(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSWindow_inst_SetRepresentedFilename(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -21346,23 +21357,23 @@ func (x gen_NSWindow) SetMiniwindowImage(
 // MiniwindowTitle returns the title displayed in the window’s minimized window.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/1419571-miniwindowtitle?language=objc for details.
-func (x gen_NSWindow) MiniwindowTitle() core.NSString {
+func (x gen_NSWindow) MiniwindowTitle() string {
 	ret := C.NSWindow_inst_MiniwindowTitle(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetMiniwindowTitle returns the title displayed in the window’s minimized window.
 //
 // See https://developer.apple.com/documentation/appkit/nswindow/1419571-miniwindowtitle?language=objc for details.
 func (x gen_NSWindow) SetMiniwindowTitle(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSWindow_inst_SetMiniwindowTitle(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -21507,11 +21518,11 @@ func (x gen_NSWorkspace) URLForApplicationToOpenURL(
 //
 // See https://developer.apple.com/documentation/appkit/nsworkspace/1534053-urlforapplicationwithbundleident?language=objc for details.
 func (x gen_NSWorkspace) URLForApplicationWithBundleIdentifier(
-	bundleIdentifier core.NSStringRef,
+	bundleIdentifier string,
 ) core.NSURL {
 	ret := C.NSWorkspace_inst_URLForApplicationWithBundleIdentifier(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(bundleIdentifier),
+		C.createNSStringFromCString(C.CString(bundleIdentifier)),
 	)
 
 	return core.NSURL_FromPointer(ret)
@@ -21535,11 +21546,11 @@ func (x gen_NSWorkspace) URLsForApplicationsToOpenURL(
 //
 // See https://developer.apple.com/documentation/appkit/nsworkspace/3753001-urlsforapplicationswithbundleide?language=objc for details.
 func (x gen_NSWorkspace) URLsForApplicationsWithBundleIdentifier(
-	bundleIdentifier core.NSStringRef,
+	bundleIdentifier string,
 ) core.NSArray {
 	ret := C.NSWorkspace_inst_URLsForApplicationsWithBundleIdentifier(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(bundleIdentifier),
+		C.createNSStringFromCString(C.CString(bundleIdentifier)),
 	)
 
 	return core.NSArray_FromPointer(ret)
@@ -21616,11 +21627,11 @@ func (x gen_NSWorkspace) HideOtherApplications() {
 //
 // See https://developer.apple.com/documentation/appkit/nsworkspace/1528158-iconforfile?language=objc for details.
 func (x gen_NSWorkspace) IconForFile(
-	fullPath core.NSStringRef,
+	fullPath string,
 ) NSImage {
 	ret := C.NSWorkspace_inst_IconForFile(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(fullPath),
+		C.createNSStringFromCString(C.CString(fullPath)),
 	)
 
 	return NSImage_FromPointer(ret)
@@ -21644,11 +21655,11 @@ func (x gen_NSWorkspace) IconForFiles(
 //
 // See https://developer.apple.com/documentation/appkit/nsworkspace/1529991-isfilepackageatpath?language=objc for details.
 func (x gen_NSWorkspace) IsFilePackageAtPath(
-	fullPath core.NSStringRef,
+	fullPath string,
 ) bool {
 	ret := C.NSWorkspace_inst_IsFilePackageAtPath(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(fullPath),
+		C.createNSStringFromCString(C.CString(fullPath)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -21658,11 +21669,11 @@ func (x gen_NSWorkspace) IsFilePackageAtPath(
 //
 // See https://developer.apple.com/documentation/appkit/nsworkspace/1525376-notefilesystemchanged?language=objc for details.
 func (x gen_NSWorkspace) NoteFileSystemChanged(
-	path core.NSStringRef,
+	path string,
 ) {
 	C.NSWorkspace_inst_NoteFileSystemChanged(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 	)
 
 	return
@@ -21686,13 +21697,13 @@ func (x gen_NSWorkspace) OpenURL(
 //
 // See https://developer.apple.com/documentation/appkit/nsworkspace/1524399-selectfile?language=objc for details.
 func (x gen_NSWorkspace) SelectFileInFileViewerRootedAtPath(
-	fullPath core.NSStringRef,
-	rootFullPath core.NSStringRef,
+	fullPath string,
+	rootFullPath string,
 ) bool {
 	ret := C.NSWorkspace_inst_SelectFileInFileViewerRootedAtPath(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(fullPath),
-		objc.RefPointer(rootFullPath),
+		C.createNSStringFromCString(C.CString(fullPath)),
+		C.createNSStringFromCString(C.CString(rootFullPath)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -21722,11 +21733,11 @@ func (x gen_NSWorkspace) SetDesktopImageURLForScreenOptionsError(
 //
 // See https://developer.apple.com/documentation/appkit/nsworkspace/1532131-showsearchresultsforquerystring?language=objc for details.
 func (x gen_NSWorkspace) ShowSearchResultsForQueryString(
-	queryString core.NSStringRef,
+	queryString string,
 ) bool {
 	ret := C.NSWorkspace_inst_ShowSearchResultsForQueryString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(queryString),
+		C.createNSStringFromCString(C.CString(queryString)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -21736,11 +21747,11 @@ func (x gen_NSWorkspace) ShowSearchResultsForQueryString(
 //
 // See https://developer.apple.com/documentation/appkit/nsworkspace/1527741-unmountandejectdeviceatpath?language=objc for details.
 func (x gen_NSWorkspace) UnmountAndEjectDeviceAtPath(
-	path core.NSStringRef,
+	path string,
 ) bool {
 	ret := C.NSWorkspace_inst_UnmountAndEjectDeviceAtPath(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -22602,23 +22613,23 @@ func (x gen_NSColor) BrightnessComponent() core.CGFloat {
 // LocalizedCatalogNameComponent returns the localized version of the catalog name containing the color.
 //
 // See https://developer.apple.com/documentation/appkit/nscolor/1535351-localizedcatalognamecomponent?language=objc for details.
-func (x gen_NSColor) LocalizedCatalogNameComponent() core.NSString {
+func (x gen_NSColor) LocalizedCatalogNameComponent() string {
 	ret := C.NSColor_inst_LocalizedCatalogNameComponent(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // LocalizedColorNameComponent returns the localized version of the color name.
 //
 // See https://developer.apple.com/documentation/appkit/nscolor/1527286-localizedcolornamecomponent?language=objc for details.
-func (x gen_NSColor) LocalizedColorNameComponent() core.NSString {
+func (x gen_NSColor) LocalizedColorNameComponent() string {
 	ret := C.NSColor_inst_LocalizedColorNameComponent(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 type NSTextViewRef interface {
@@ -26733,12 +26744,12 @@ func (x gen_NSView) WantsDefaultClipping() bool {
 // PrintJobTitle returns the view’s print job title.
 //
 // See https://developer.apple.com/documentation/appkit/nsview/1483753-printjobtitle?language=objc for details.
-func (x gen_NSView) PrintJobTitle() core.NSString {
+func (x gen_NSView) PrintJobTitle() string {
 	ret := C.NSView_inst_PrintJobTitle(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // PageHeader returns a default header string that includes the print job title and date.
@@ -27385,23 +27396,23 @@ func (x gen_NSView) Tag() core.NSInteger {
 // ToolTip returns the text for the view’s tooltip.
 //
 // See https://developer.apple.com/documentation/appkit/nsview/1483541-tooltip?language=objc for details.
-func (x gen_NSView) ToolTip() core.NSString {
+func (x gen_NSView) ToolTip() string {
 	ret := C.NSView_inst_ToolTip(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetToolTip returns the text for the view’s tooltip.
 //
 // See https://developer.apple.com/documentation/appkit/nsview/1483541-tooltip?language=objc for details.
 func (x gen_NSView) SetToolTip(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.NSView_inst_SetToolTip(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return

--- a/cocoa/init.go
+++ b/cocoa/init.go
@@ -8,7 +8,3 @@ import "C"
 func Color(r, g, b, a float64) NSColor {
 	return NSColor_Init(r, g, b, a)
 }
-
-func Font(fontName string, size float64) NSFont {
-	return NSFont_Init(fontName, size)
-}

--- a/cocoa/init.go
+++ b/cocoa/init.go
@@ -8,3 +8,7 @@ import "C"
 func Color(r, g, b, a float64) NSColor {
 	return NSColor_Init(r, g, b, a)
 }
+
+func Font(fontName string, size float64) NSFont {
+	return NSFont_Init(fontName, size)
+}

--- a/core/NSAttributedString.go
+++ b/core/NSAttributedString.go
@@ -13,8 +13,7 @@ type NSAttributedString struct {
 // NSAttributedString_FromString returns an initialized NSAttributedString
 // https://developer.apple.com/documentation/foundation/nsattributedstring/1407481-initwithstring?language=objc
 func NSAttributedString_FromString(str string) NSAttributedString {
-	nsstr := NSString_FromString(str)
-	return NSAttributedString_Alloc().InitWithString(nsstr)
+	return NSAttributedString_Alloc().InitWithString(str)
 }
 
 func NSAttributedString_FromObject(obj objc.Object) NSAttributedString {

--- a/core/NSURL.go
+++ b/core/NSURL.go
@@ -1,7 +1,3 @@
 package core
 
 type NSURL struct{ gen_NSURL }
-
-func NSURL_Init(url string) NSURL {
-	return NSURL_URLWithString(String(url))
-}

--- a/core/core_objc.gen.go
+++ b/core/core_objc.gen.go
@@ -21,6 +21,17 @@ bool core_convertObjCBool(BOOL b) {
 	return false;
 }
 
+// Creates a NSString from a C string
+static void *createNSStringFromCString(char *cString) {
+    return [NSString stringWithCString: cString encoding: NSUTF8StringEncoding];
+}
+
+// Creates a C string from a NSString
+static char *createCStringFromNSString(void *objcString)
+{
+    return [objcString UTF8String];
+}
+
 
 void* NSObject_type_Alloc() {
 	return [NSObject
@@ -2729,10 +2740,10 @@ func NSObject_InstancesRespondToSelector(aSelector objc.Selector) bool {
 // NSObject_Description returns a string that represents the contents of the receiving class.
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1418799-description?language=objc for details.
-func NSObject_Description() NSString {
+func NSObject_Description() string {
 	ret := C.NSObject_type_Description()
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // NSObject_CancelPreviousPerformRequestsWithTarget cancels perform requests previously registered with the performSelector:withObject:afterDelay: instance method.
@@ -2813,10 +2824,10 @@ func NSObject_Version() NSInteger {
 // NSObject_DebugDescription is undocumented.
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1418711-debugdescription?language=objc for details.
-func NSObject_DebugDescription() NSString {
+func NSObject_DebugDescription() string {
 	ret := C.NSObject_type_DebugDescription()
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // NSObject_Hash is undocumented.
@@ -2847,9 +2858,9 @@ func CALayer_Layer() CALayer {
 // CALayer_NeedsDisplayForKey returns a Boolean indicating whether changes to the specified key require the layer to be redisplayed.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410769-needsdisplayforkey?language=objc for details.
-func CALayer_NeedsDisplayForKey(key NSStringRef) bool {
+func CALayer_NeedsDisplayForKey(key string) bool {
 	ret := C.CALayer_type_NeedsDisplayForKey(
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -2858,9 +2869,9 @@ func CALayer_NeedsDisplayForKey(key NSStringRef) bool {
 // CALayer_DefaultActionForKey returns the default action for the current class.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410954-defaultactionforkey?language=objc for details.
-func CALayer_DefaultActionForKey(event NSStringRef) objc.Object {
+func CALayer_DefaultActionForKey(event string) objc.Object {
 	ret := C.CALayer_type_DefaultActionForKey(
-		objc.RefPointer(event),
+		C.createNSStringFromCString(C.CString(event)),
 	)
 
 	return objc.Object_FromPointer(ret)
@@ -2869,9 +2880,9 @@ func CALayer_DefaultActionForKey(event NSStringRef) objc.Object {
 // CALayer_DefaultValueForKey specifies the default value associated with the specified key.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410886-defaultvalueforkey?language=objc for details.
-func CALayer_DefaultValueForKey(key NSStringRef) objc.Object {
+func CALayer_DefaultValueForKey(key string) objc.Object {
 	ret := C.CALayer_type_DefaultValueForKey(
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 	)
 
 	return objc.Object_FromPointer(ret)
@@ -3008,9 +3019,9 @@ func NSData_DataWithData(data NSDataRef) NSData {
 // NSData_DataWithContentsOfFile creates a data object by reading every byte from the file at a given path.
 //
 // See https://developer.apple.com/documentation/foundation/nsdata/1547226-datawithcontentsoffile?language=objc for details.
-func NSData_DataWithContentsOfFile(path NSStringRef) NSData {
+func NSData_DataWithContentsOfFile(path string) NSData {
 	ret := C.NSData_type_DataWithContentsOfFile(
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 	)
 
 	return NSData_FromPointer(ret)
@@ -3202,21 +3213,21 @@ func NSString_String() NSString {
 // NSString_LocalizedUserNotificationStringForKeyArguments returns a localized string intended for display in a notification alert.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1649585-localizedusernotificationstringf?language=objc for details.
-func NSString_LocalizedUserNotificationStringForKeyArguments(key NSStringRef, arguments NSArrayRef) NSString {
+func NSString_LocalizedUserNotificationStringForKeyArguments(key string, arguments NSArrayRef) string {
 	ret := C.NSString_type_LocalizedUserNotificationStringForKeyArguments(
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 		objc.RefPointer(arguments),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // NSString_StringWithString returns a string created by copying the characters from another given string.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1497372-stringwithstring?language=objc for details.
-func NSString_StringWithString(string NSStringRef) NSString {
+func NSString_StringWithString(string string) NSString {
 	ret := C.NSString_type_StringWithString(
-		objc.RefPointer(string),
+		C.createNSStringFromCString(C.CString(string)),
 	)
 
 	return NSString_FromPointer(ret)
@@ -3225,49 +3236,49 @@ func NSString_StringWithString(string NSStringRef) NSString {
 // NSString_StringWithContentsOfFileEncodingError returns a string created by reading data from the file at a given path interpreted using a given encoding.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1497327-stringwithcontentsoffile?language=objc for details.
-func NSString_StringWithContentsOfFileEncodingError(path NSStringRef, enc NSStringEncoding, error NSErrorRef) NSString {
+func NSString_StringWithContentsOfFileEncodingError(path string, enc NSStringEncoding, error NSErrorRef) string {
 	ret := C.NSString_type_StringWithContentsOfFileEncodingError(
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		C.ulong(enc),
 		objc.RefPointer(error),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // NSString_StringWithContentsOfURLEncodingError returns a string created by reading data from a given URL interpreted using a given encoding.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1497360-stringwithcontentsofurl?language=objc for details.
-func NSString_StringWithContentsOfURLEncodingError(url NSURLRef, enc NSStringEncoding, error NSErrorRef) NSString {
+func NSString_StringWithContentsOfURLEncodingError(url NSURLRef, enc NSStringEncoding, error NSErrorRef) string {
 	ret := C.NSString_type_StringWithContentsOfURLEncodingError(
 		objc.RefPointer(url),
 		C.ulong(enc),
 		objc.RefPointer(error),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // NSString_LocalizedNameOfStringEncoding returns a human-readable string giving the name of a given encoding.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1408318-localizednameofstringencoding?language=objc for details.
-func NSString_LocalizedNameOfStringEncoding(encoding NSStringEncoding) NSString {
+func NSString_LocalizedNameOfStringEncoding(encoding NSStringEncoding) string {
 	ret := C.NSString_type_LocalizedNameOfStringEncoding(
 		C.ulong(encoding),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // NSString_PathWithComponents returns a string built from the strings in a given array by concatenating them with a path separator between each pair.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1417198-pathwithcomponents?language=objc for details.
-func NSString_PathWithComponents(components NSArrayRef) NSString {
+func NSString_PathWithComponents(components NSArrayRef) string {
 	ret := C.NSString_type_PathWithComponents(
 		objc.RefPointer(components),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // NSString_DefaultCStringEncoding returns the C-string encoding assumed for any method accepting a C string as an argument.
@@ -3372,9 +3383,9 @@ func NSURL_Alloc() NSURL {
 // NSURL_URLWithString creates and returns an NSURL object initialized with a provided URL string.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1572047-urlwithstring?language=objc for details.
-func NSURL_URLWithString(URLString NSStringRef) NSURL {
+func NSURL_URLWithString(URLString string) NSURL {
 	ret := C.NSURL_type_URLWithString(
-		objc.RefPointer(URLString),
+		C.createNSStringFromCString(C.CString(URLString)),
 	)
 
 	return NSURL_FromPointer(ret)
@@ -3383,9 +3394,9 @@ func NSURL_URLWithString(URLString NSStringRef) NSURL {
 // NSURL_URLWithStringRelativeToURL creates and returns an NSURL object initialized with a base URL and a relative string.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1572049-urlwithstring?language=objc for details.
-func NSURL_URLWithStringRelativeToURL(URLString NSStringRef, baseURL NSURLRef) NSURL {
+func NSURL_URLWithStringRelativeToURL(URLString string, baseURL NSURLRef) NSURL {
 	ret := C.NSURL_type_URLWithStringRelativeToURL(
-		objc.RefPointer(URLString),
+		C.createNSStringFromCString(C.CString(URLString)),
 		objc.RefPointer(baseURL),
 	)
 
@@ -3395,9 +3406,9 @@ func NSURL_URLWithStringRelativeToURL(URLString NSStringRef, baseURL NSURLRef) N
 // NSURL_FileURLWithPathIsDirectory initializes and returns a newly created NSURL object as a file URL with a specified path.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1414650-fileurlwithpath?language=objc for details.
-func NSURL_FileURLWithPathIsDirectory(path NSStringRef, isDir bool) NSURL {
+func NSURL_FileURLWithPathIsDirectory(path string, isDir bool) NSURL {
 	ret := C.NSURL_type_FileURLWithPathIsDirectory(
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		convertToObjCBool(isDir),
 	)
 
@@ -3407,9 +3418,9 @@ func NSURL_FileURLWithPathIsDirectory(path NSStringRef, isDir bool) NSURL {
 // NSURL_FileURLWithPathRelativeToURL is undocumented.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1413201-fileurlwithpath?language=objc for details.
-func NSURL_FileURLWithPathRelativeToURL(path NSStringRef, baseURL NSURLRef) NSURL {
+func NSURL_FileURLWithPathRelativeToURL(path string, baseURL NSURLRef) NSURL {
 	ret := C.NSURL_type_FileURLWithPathRelativeToURL(
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		objc.RefPointer(baseURL),
 	)
 
@@ -3419,9 +3430,9 @@ func NSURL_FileURLWithPathRelativeToURL(path NSStringRef, baseURL NSURLRef) NSUR
 // NSURL_FileURLWithPathIsDirectoryRelativeToURL is undocumented.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1413020-fileurlwithpath?language=objc for details.
-func NSURL_FileURLWithPathIsDirectoryRelativeToURL(path NSStringRef, isDir bool, baseURL NSURLRef) NSURL {
+func NSURL_FileURLWithPathIsDirectoryRelativeToURL(path string, isDir bool, baseURL NSURLRef) NSURL {
 	ret := C.NSURL_type_FileURLWithPathIsDirectoryRelativeToURL(
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		convertToObjCBool(isDir),
 		objc.RefPointer(baseURL),
 	)
@@ -3432,9 +3443,9 @@ func NSURL_FileURLWithPathIsDirectoryRelativeToURL(path NSStringRef, isDir bool,
 // NSURL_FileURLWithPath initializes and returns a newly created NSURL object as a file URL with a specified path.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1410828-fileurlwithpath?language=objc for details.
-func NSURL_FileURLWithPath(path NSStringRef) NSURL {
+func NSURL_FileURLWithPath(path string) NSURL {
 	ret := C.NSURL_type_FileURLWithPath(
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 	)
 
 	return NSURL_FromPointer(ret)
@@ -3573,12 +3584,12 @@ func NSObject_FromRef(ref objc.Ref) NSObject {
 // ActionProperty sent to the delegate to request the property the action applies to.
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1411302-actionproperty?language=objc for details.
-func (x gen_NSObject) ActionProperty() NSString {
+func (x gen_NSObject) ActionProperty() string {
 	ret := C.NSObject_inst_ActionProperty(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // AttemptRecoveryFromErrorOptionIndex implemented to attempt a recovery from an error noted in an application-modal dialog.
@@ -3677,13 +3688,13 @@ func (x gen_NSObject) Copy() objc.Object {
 // See https://developer.apple.com/documentation/objectivec/nsobject/1410291-copyscriptingvalue?language=objc for details.
 func (x gen_NSObject) CopyScriptingValueForKeyWithProperties(
 	value objc.Ref,
-	key NSStringRef,
+	key string,
 	properties NSDictionaryRef,
 ) objc.Object {
 	ret := C.NSObject_inst_CopyScriptingValueForKeyWithProperties(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(value),
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 		objc.RefPointer(properties),
 	)
 
@@ -3773,45 +3784,45 @@ func (x gen_NSObject) ImageRepresentation() objc.Object {
 // ImageRepresentationType returns the representation type of the image to display.
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1503547-imagerepresentationtype?language=objc for details.
-func (x gen_NSObject) ImageRepresentationType() NSString {
+func (x gen_NSObject) ImageRepresentationType() string {
 	ret := C.NSObject_inst_ImageRepresentationType(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // ImageSubtitle returns the display subtitle of the image.
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1503725-imagesubtitle?language=objc for details.
-func (x gen_NSObject) ImageSubtitle() NSString {
+func (x gen_NSObject) ImageSubtitle() string {
 	ret := C.NSObject_inst_ImageSubtitle(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // ImageTitle returns the display title of the image.
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1504080-imagetitle?language=objc for details.
-func (x gen_NSObject) ImageTitle() NSString {
+func (x gen_NSObject) ImageTitle() string {
 	ret := C.NSObject_inst_ImageTitle(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // ImageUID returns a unique string that identifies the data source item.
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1503516-imageuid?language=objc for details.
-func (x gen_NSObject) ImageUID() NSString {
+func (x gen_NSObject) ImageUID() string {
 	ret := C.NSObject_inst_ImageUID(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // ImageVersion returns the version of the item.
@@ -3851,12 +3862,12 @@ func (x gen_NSObject) Init_AsNSObject() NSObject {
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1385446-inputtext?language=objc for details.
 func (x gen_NSObject) InputTextClient(
-	string NSStringRef,
+	string string,
 	sender objc.Ref,
 ) bool {
 	ret := C.NSObject_inst_InputTextClient(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(string),
+		C.createNSStringFromCString(C.CString(string)),
 		objc.RefPointer(sender),
 	)
 
@@ -3867,14 +3878,14 @@ func (x gen_NSObject) InputTextClient(
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1385436-inputtext?language=objc for details.
 func (x gen_NSObject) InputTextKeyModifiersClient(
-	string NSStringRef,
+	string string,
 	keyCode NSInteger,
 	flags NSUInteger,
 	sender objc.Ref,
 ) bool {
 	ret := C.NSObject_inst_InputTextKeyModifiersClient(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(string),
+		C.createNSStringFromCString(C.CString(string)),
 		C.long(keyCode),
 		C.ulong(flags),
 		objc.RefPointer(sender),
@@ -3887,25 +3898,25 @@ func (x gen_NSObject) InputTextKeyModifiersClient(
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1411046-inverseforrelationshipkey?language=objc for details.
 func (x gen_NSObject) InverseForRelationshipKey(
-	relationshipKey NSStringRef,
-) NSString {
+	relationshipKey string,
+) string {
 	ret := C.NSObject_inst_InverseForRelationshipKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(relationshipKey),
+		C.createNSStringFromCString(C.CString(relationshipKey)),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // IsCaseInsensitiveLike returns a Boolean value that indicates whether receiver is considered to be “like” a given string when the case of characters in the receiver is ignored.
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1393837-iscaseinsensitivelike?language=objc for details.
 func (x gen_NSObject) IsCaseInsensitiveLike(
-	object NSStringRef,
+	object string,
 ) bool {
 	ret := C.NSObject_inst_IsCaseInsensitiveLike(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(object),
+		C.createNSStringFromCString(C.CString(object)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -3985,11 +3996,11 @@ func (x gen_NSObject) IsLessThanOrEqualTo(
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1393866-islike?language=objc for details.
 func (x gen_NSObject) IsLike(
-	object NSStringRef,
+	object string,
 ) bool {
 	ret := C.NSObject_inst_IsLike(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(object),
+		C.createNSStringFromCString(C.CString(object)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -4177,12 +4188,12 @@ func (x gen_NSObject) ToOneRelationshipKeys() NSArray {
 // ClassName returns a string containing the name of the class.
 //
 // See https://developer.apple.com/documentation/objectivec/nsobject/1411337-classname?language=objc for details.
-func (x gen_NSObject) ClassName() NSString {
+func (x gen_NSObject) ClassName() string {
 	ret := C.NSObject_inst_ClassName(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // ScriptingProperties an NSString-keyed dictionary of the receiver's scriptable properties.
@@ -4255,11 +4266,11 @@ func CALayer_FromRef(ref objc.Ref) CALayer {
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410844-actionforkey?language=objc for details.
 func (x gen_CALayer) ActionForKey(
-	event NSStringRef,
+	event string,
 ) objc.Object {
 	ret := C.CALayer_inst_ActionForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(event),
+		C.createNSStringFromCString(C.CString(event)),
 	)
 
 	return objc.Object_FromPointer(ret)
@@ -4531,11 +4542,11 @@ func (x gen_CALayer) RemoveAllAnimations() {
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410939-removeanimationforkey?language=objc for details.
 func (x gen_CALayer) RemoveAnimationForKey(
-	key NSStringRef,
+	key string,
 ) {
 	C.CALayer_inst_RemoveAnimationForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 	)
 
 	return
@@ -4650,11 +4661,11 @@ func (x gen_CALayer) SetNeedsLayout() {
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410753-shouldarchivevalueforkey?language=objc for details.
 func (x gen_CALayer) ShouldArchiveValueForKey(
-	key NSStringRef,
+	key string,
 ) bool {
 	ret := C.CALayer_inst_ShouldArchiveValueForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -5510,23 +5521,23 @@ func (x gen_CALayer) VisibleRect() NSRect {
 // Name returns the name of the receiver.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410879-name?language=objc for details.
-func (x gen_CALayer) Name() NSString {
+func (x gen_CALayer) Name() string {
 	ret := C.CALayer_inst_Name(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetName returns the name of the receiver.
 //
 // See https://developer.apple.com/documentation/quartzcore/calayer/1410879-name?language=objc for details.
 func (x gen_CALayer) SetName(
-	value NSStringRef,
+	value string,
 ) {
 	C.CALayer_inst_SetName(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -5569,14 +5580,14 @@ func (x gen_NSArray) ArrayByAddingObjectsFromArray(
 //
 // See https://developer.apple.com/documentation/foundation/nsarray/1412075-componentsjoinedbystring?language=objc for details.
 func (x gen_NSArray) ComponentsJoinedByString(
-	separator NSStringRef,
-) NSString {
+	separator string,
+) string {
 	ret := C.NSArray_inst_ComponentsJoinedByString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(separator),
+		C.createNSStringFromCString(C.CString(separator)),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // DescriptionWithLocale returns a string that represents the contents of the array, formatted as a property list.
@@ -5584,13 +5595,13 @@ func (x gen_NSArray) ComponentsJoinedByString(
 // See https://developer.apple.com/documentation/foundation/nsarray/1412374-descriptionwithlocale?language=objc for details.
 func (x gen_NSArray) DescriptionWithLocale(
 	locale objc.Ref,
-) NSString {
+) string {
 	ret := C.NSArray_inst_DescriptionWithLocale(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(locale),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // DescriptionWithLocaleIndent returns a string that represents the contents of the array, formatted as a property list.
@@ -5599,14 +5610,14 @@ func (x gen_NSArray) DescriptionWithLocale(
 func (x gen_NSArray) DescriptionWithLocaleIndent(
 	locale objc.Ref,
 	level NSUInteger,
-) NSString {
+) string {
 	ret := C.NSArray_inst_DescriptionWithLocaleIndent(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(locale),
 		C.ulong(level),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Init initializes a newly allocated array.
@@ -5740,12 +5751,12 @@ func (x gen_NSArray) PathsMatchingExtensions(
 // See https://developer.apple.com/documentation/foundation/nsarray/1414976-removeobserver?language=objc for details.
 func (x gen_NSArray) RemoveObserverForKeyPath(
 	observer NSObjectRef,
-	keyPath NSStringRef,
+	keyPath string,
 ) {
 	C.NSArray_inst_RemoveObserverForKeyPath(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(observer),
-		objc.RefPointer(keyPath),
+		C.createNSStringFromCString(C.CString(keyPath)),
 	)
 
 	return
@@ -5756,13 +5767,13 @@ func (x gen_NSArray) RemoveObserverForKeyPath(
 // See https://developer.apple.com/documentation/foundation/nsarray/1418441-removeobserver?language=objc for details.
 func (x gen_NSArray) RemoveObserverForKeyPathContext(
 	observer NSObjectRef,
-	keyPath NSStringRef,
+	keyPath string,
 	context unsafe.Pointer,
 ) {
 	C.NSArray_inst_RemoveObserverForKeyPathContext(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(observer),
-		objc.RefPointer(keyPath),
+		C.createNSStringFromCString(C.CString(keyPath)),
 		context,
 	)
 
@@ -5774,12 +5785,12 @@ func (x gen_NSArray) RemoveObserverForKeyPathContext(
 // See https://developer.apple.com/documentation/foundation/nsarray/1408301-setvalue?language=objc for details.
 func (x gen_NSArray) SetValueForKey(
 	value objc.Ref,
-	key NSStringRef,
+	key string,
 ) {
 	C.NSArray_inst_SetValueForKey(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(value),
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 	)
 
 	return
@@ -5828,11 +5839,11 @@ func (x gen_NSArray) SortedArrayUsingSelector(
 //
 // See https://developer.apple.com/documentation/foundation/nsarray/1412219-valueforkey?language=objc for details.
 func (x gen_NSArray) ValueForKey(
-	key NSStringRef,
+	key string,
 ) objc.Object {
 	ret := C.NSArray_inst_ValueForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 	)
 
 	return objc.Object_FromPointer(ret)
@@ -5879,12 +5890,12 @@ func (x gen_NSArray) SortedArrayHint() NSData {
 // Description returns a string that represents the contents of the array, formatted as a property list.
 //
 // See https://developer.apple.com/documentation/foundation/nsarray/1413042-description?language=objc for details.
-func (x gen_NSArray) Description() NSString {
+func (x gen_NSArray) Description() string {
 	ret := C.NSArray_inst_Description(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 type NSAttributedStringRef interface {
@@ -6069,11 +6080,11 @@ func (x gen_NSAttributedString) InitWithRTFDDocumentAttributes(
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1407481-initwithstring?language=objc for details.
 func (x gen_NSAttributedString) InitWithString(
-	str NSStringRef,
+	str string,
 ) NSAttributedString {
 	ret := C.NSAttributedString_inst_InitWithString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(str),
+		C.createNSStringFromCString(C.CString(str)),
 	)
 
 	return NSAttributedString_FromPointer(ret)
@@ -6083,12 +6094,12 @@ func (x gen_NSAttributedString) InitWithString(
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1408136-initwithstring?language=objc for details.
 func (x gen_NSAttributedString) InitWithStringAttributes(
-	str NSStringRef,
+	str string,
 	attrs NSDictionaryRef,
 ) NSAttributedString {
 	ret := C.NSAttributedString_inst_InitWithStringAttributes(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(str),
+		C.createNSStringFromCString(C.CString(str)),
 		objc.RefPointer(attrs),
 	)
 
@@ -6177,12 +6188,12 @@ func (x gen_NSAttributedString) Init_AsNSAttributedString() NSAttributedString {
 // String returns the character contents of the attributed string as a string.
 //
 // See https://developer.apple.com/documentation/foundation/nsattributedstring/1412616-string?language=objc for details.
-func (x gen_NSAttributedString) String() NSString {
+func (x gen_NSAttributedString) String() string {
 	ret := C.NSAttributedString_inst_String(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Length returns the length of the attributed string.
@@ -6285,11 +6296,11 @@ func (x gen_NSData) InitWithBytesNoCopyLengthFreeWhenDone(
 //
 // See https://developer.apple.com/documentation/foundation/nsdata/1408672-initwithcontentsoffile?language=objc for details.
 func (x gen_NSData) InitWithContentsOfFile(
-	path NSStringRef,
+	path string,
 ) NSData {
 	ret := C.NSData_inst_InitWithContentsOfFile(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 	)
 
 	return NSData_FromPointer(ret)
@@ -6341,12 +6352,12 @@ func (x gen_NSData) IsEqualToData(
 //
 // See https://developer.apple.com/documentation/foundation/nsdata/1408033-writetofile?language=objc for details.
 func (x gen_NSData) WriteToFileAtomically(
-	path NSStringRef,
+	path string,
 	useAuxiliaryFile bool,
 ) bool {
 	ret := C.NSData_inst_WriteToFileAtomically(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		convertToObjCBool(useAuxiliaryFile),
 	)
 
@@ -6412,12 +6423,12 @@ func (x gen_NSData) Length() NSUInteger {
 // Description returns a string that contains a hexadecimal representation of the data object’s contents in a property list format.
 //
 // See https://developer.apple.com/documentation/foundation/nsdata/1412579-description?language=objc for details.
-func (x gen_NSData) Description() NSString {
+func (x gen_NSData) Description() string {
 	ret := C.NSData_inst_Description(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 type NSDictionaryRef interface {
@@ -6444,13 +6455,13 @@ func NSDictionary_FromRef(ref objc.Ref) NSDictionary {
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1417665-descriptionwithlocale?language=objc for details.
 func (x gen_NSDictionary) DescriptionWithLocale(
 	locale objc.Ref,
-) NSString {
+) string {
 	ret := C.NSDictionary_inst_DescriptionWithLocale(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(locale),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // DescriptionWithLocaleIndent returns a string object that represents the contents of the dictionary, formatted as a property list.
@@ -6459,14 +6470,14 @@ func (x gen_NSDictionary) DescriptionWithLocale(
 func (x gen_NSDictionary) DescriptionWithLocaleIndent(
 	locale objc.Ref,
 	level NSUInteger,
-) NSString {
+) string {
 	ret := C.NSDictionary_inst_DescriptionWithLocaleIndent(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(locale),
 		C.ulong(level),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // FileExtensionHidden returns a Boolean value indicating whether the file hides its extension.
@@ -6494,12 +6505,12 @@ func (x gen_NSDictionary) FileGroupOwnerAccountID() NSNumber {
 // FileGroupOwnerAccountName returns the file’s group owner account name.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1416788-filegroupowneraccountname?language=objc for details.
-func (x gen_NSDictionary) FileGroupOwnerAccountName() NSString {
+func (x gen_NSDictionary) FileGroupOwnerAccountName() string {
 	ret := C.NSDictionary_inst_FileGroupOwnerAccountName(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // FileIsAppendOnly returns a Boolean value indicating whether the file is append only.
@@ -6538,12 +6549,12 @@ func (x gen_NSDictionary) FileOwnerAccountID() NSNumber {
 // FileOwnerAccountName returns the file’s owner account name.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1417533-fileowneraccountname?language=objc for details.
-func (x gen_NSDictionary) FileOwnerAccountName() NSString {
+func (x gen_NSDictionary) FileOwnerAccountName() string {
 	ret := C.NSDictionary_inst_FileOwnerAccountName(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // FilePosixPermissions returns the file’s POSIX permissions.
@@ -6582,12 +6593,12 @@ func (x gen_NSDictionary) FileSystemNumber() NSInteger {
 // FileType returns the file type.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1416809-filetype?language=objc for details.
-func (x gen_NSDictionary) FileType() NSString {
+func (x gen_NSDictionary) FileType() string {
 	ret := C.NSDictionary_inst_FileType(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Init initializes a newly allocated dictionary.
@@ -6754,23 +6765,23 @@ func (x gen_NSDictionary) AllValues() NSArray {
 // Description returns a string that represents the contents of the dictionary, formatted as a property list.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1410799-description?language=objc for details.
-func (x gen_NSDictionary) Description() NSString {
+func (x gen_NSDictionary) Description() string {
 	ret := C.NSDictionary_inst_Description(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // DescriptionInStringsFileFormat returns a string that represents the contents of the dictionary, formatted in .strings file format.
 //
 // See https://developer.apple.com/documentation/foundation/nsdictionary/1413282-descriptioninstringsfileformat?language=objc for details.
-func (x gen_NSDictionary) DescriptionInStringsFileFormat() NSString {
+func (x gen_NSDictionary) DescriptionInStringsFileFormat() string {
 	ret := C.NSDictionary_inst_DescriptionInStringsFileFormat(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 type NSErrorRef interface {
@@ -6835,12 +6846,12 @@ func (x gen_NSError) UserInfo() NSDictionary {
 // LocalizedDescription returns a string containing the localized description of the error.
 //
 // See https://developer.apple.com/documentation/foundation/nserror/1414418-localizeddescription?language=objc for details.
-func (x gen_NSError) LocalizedDescription() NSString {
+func (x gen_NSError) LocalizedDescription() string {
 	ret := C.NSError_inst_LocalizedDescription(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // LocalizedRecoveryOptions an array containing the localized titles of buttons appropriate for displaying in an alert panel.
@@ -6857,23 +6868,23 @@ func (x gen_NSError) LocalizedRecoveryOptions() NSArray {
 // LocalizedRecoverySuggestion returns a string containing the localized recovery suggestion for the error.
 //
 // See https://developer.apple.com/documentation/foundation/nserror/1407500-localizedrecoverysuggestion?language=objc for details.
-func (x gen_NSError) LocalizedRecoverySuggestion() NSString {
+func (x gen_NSError) LocalizedRecoverySuggestion() string {
 	ret := C.NSError_inst_LocalizedRecoverySuggestion(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // LocalizedFailureReason returns a string containing the localized explanation of the reason for the error.
 //
 // See https://developer.apple.com/documentation/foundation/nserror/1412752-localizedfailurereason?language=objc for details.
-func (x gen_NSError) LocalizedFailureReason() NSString {
+func (x gen_NSError) LocalizedFailureReason() string {
 	ret := C.NSError_inst_LocalizedFailureReason(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // RecoveryAttempter returns the object in the user info dictionary corresponding to the NSRecoveryAttempterErrorKey key.
@@ -6890,12 +6901,12 @@ func (x gen_NSError) RecoveryAttempter() objc.Object {
 // HelpAnchor returns a string to display in response to an alert panel help anchor button being pressed.
 //
 // See https://developer.apple.com/documentation/foundation/nserror/1414718-helpanchor?language=objc for details.
-func (x gen_NSError) HelpAnchor() NSString {
+func (x gen_NSError) HelpAnchor() string {
 	ret := C.NSError_inst_HelpAnchor(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // UnderlyingErrors is undocumented.
@@ -6933,13 +6944,13 @@ func NSNumber_FromRef(ref objc.Ref) NSNumber {
 // See https://developer.apple.com/documentation/foundation/nsnumber/1409984-descriptionwithlocale?language=objc for details.
 func (x gen_NSNumber) DescriptionWithLocale(
 	locale objc.Ref,
-) NSString {
+) string {
 	ret := C.NSNumber_inst_DescriptionWithLocale(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(locale),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // InitWithBool returns an NSNumber object initialized to contain a given value, treated as a BOOL.
@@ -7102,12 +7113,12 @@ func (x gen_NSNumber) UnsignedIntValue() int32 {
 // StringValue returns the number object's value expressed as a human-readable string.
 //
 // See https://developer.apple.com/documentation/foundation/nsnumber/1415802-stringvalue?language=objc for details.
-func (x gen_NSNumber) StringValue() NSString {
+func (x gen_NSNumber) StringValue() string {
 	ret := C.NSNumber_inst_StringValue(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 type NSRunLoopRef interface {
@@ -7263,14 +7274,14 @@ func (x gen_NSString) CharacterAtIndex(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1411841-completepathintostring?language=objc for details.
 func (x gen_NSString) CompletePathIntoStringCaseSensitiveMatchesIntoArrayFilterTypes(
-	outputName NSStringRef,
+	outputName string,
 	flag bool,
 	outputArray NSArrayRef,
 	filterTypes NSArrayRef,
 ) NSUInteger {
 	ret := C.NSString_inst_CompletePathIntoStringCaseSensitiveMatchesIntoArrayFilterTypes(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(outputName),
+		C.createNSStringFromCString(C.CString(outputName)),
 		convertToObjCBool(flag),
 		objc.RefPointer(outputArray),
 		objc.RefPointer(filterTypes),
@@ -7283,11 +7294,11 @@ func (x gen_NSString) CompletePathIntoStringCaseSensitiveMatchesIntoArrayFilterT
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1413214-componentsseparatedbystring?language=objc for details.
 func (x gen_NSString) ComponentsSeparatedByString(
-	separator NSStringRef,
+	separator string,
 ) NSArray {
 	ret := C.NSString_inst_ComponentsSeparatedByString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(separator),
+		C.createNSStringFromCString(C.CString(separator)),
 	)
 
 	return NSArray_FromPointer(ret)
@@ -7297,11 +7308,11 @@ func (x gen_NSString) ComponentsSeparatedByString(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1414563-containsstring?language=objc for details.
 func (x gen_NSString) ContainsString(
-	str NSStringRef,
+	str string,
 ) bool {
 	ret := C.NSString_inst_ContainsString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(str),
+		C.createNSStringFromCString(C.CString(str)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -7357,11 +7368,11 @@ func (x gen_NSString) DrawInRectWithAttributes(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1410309-hasprefix?language=objc for details.
 func (x gen_NSString) HasPrefix(
-	str NSStringRef,
+	str string,
 ) bool {
 	ret := C.NSString_inst_HasPrefix(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(str),
+		C.createNSStringFromCString(C.CString(str)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -7371,11 +7382,11 @@ func (x gen_NSString) HasPrefix(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1416529-hassuffix?language=objc for details.
 func (x gen_NSString) HasSuffix(
-	str NSStringRef,
+	str string,
 ) bool {
 	ret := C.NSString_inst_HasSuffix(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(str),
+		C.createNSStringFromCString(C.CString(str)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -7445,18 +7456,18 @@ func (x gen_NSString) InitWithBytesNoCopyLengthEncodingFreeWhenDone(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1412610-initwithcontentsoffile?language=objc for details.
 func (x gen_NSString) InitWithContentsOfFileEncodingError(
-	path NSStringRef,
+	path string,
 	enc NSStringEncoding,
 	error NSErrorRef,
-) NSString {
+) string {
 	ret := C.NSString_inst_InitWithContentsOfFileEncodingError(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		C.ulong(enc),
 		objc.RefPointer(error),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // InitWithContentsOfURLEncodingError returns an NSString object initialized by reading data from a given URL interpreted using a given encoding.
@@ -7466,7 +7477,7 @@ func (x gen_NSString) InitWithContentsOfURLEncodingError(
 	url NSURLRef,
 	enc NSStringEncoding,
 	error NSErrorRef,
-) NSString {
+) string {
 	ret := C.NSString_inst_InitWithContentsOfURLEncodingError(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(url),
@@ -7474,7 +7485,7 @@ func (x gen_NSString) InitWithContentsOfURLEncodingError(
 		objc.RefPointer(error),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // InitWithDataEncoding returns an NSString object initialized by converting given data into UTF-16 code units using a given encoding.
@@ -7497,11 +7508,11 @@ func (x gen_NSString) InitWithDataEncoding(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1411293-initwithstring?language=objc for details.
 func (x gen_NSString) InitWithString(
-	aString NSStringRef,
+	aString string,
 ) NSString {
 	ret := C.NSString_inst_InitWithString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(aString),
+		C.createNSStringFromCString(C.CString(aString)),
 	)
 
 	return NSString_FromPointer(ret)
@@ -7511,11 +7522,11 @@ func (x gen_NSString) InitWithString(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1407803-isequaltostring?language=objc for details.
 func (x gen_NSString) IsEqualToString(
-	aString NSStringRef,
+	aString string,
 ) bool {
 	ret := C.NSString_inst_IsEqualToString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(aString),
+		C.createNSStringFromCString(C.CString(aString)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -7539,11 +7550,11 @@ func (x gen_NSString) LengthOfBytesUsingEncoding(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1412098-localizedcaseinsensitivecontains?language=objc for details.
 func (x gen_NSString) LocalizedCaseInsensitiveContainsString(
-	str NSStringRef,
+	str string,
 ) bool {
 	ret := C.NSString_inst_LocalizedCaseInsensitiveContainsString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(str),
+		C.createNSStringFromCString(C.CString(str)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -7553,11 +7564,11 @@ func (x gen_NSString) LocalizedCaseInsensitiveContainsString(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1416328-localizedstandardcontainsstring?language=objc for details.
 func (x gen_NSString) LocalizedStandardContainsString(
-	str NSStringRef,
+	str string,
 ) bool {
 	ret := C.NSString_inst_LocalizedStandardContainsString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(str),
+		C.createNSStringFromCString(C.CString(str)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -7617,42 +7628,42 @@ func (x gen_NSString) SizeWithAttributes(
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1417069-stringbyappendingpathcomponent?language=objc for details.
 func (x gen_NSString) StringByAppendingPathComponent(
-	str NSStringRef,
-) NSString {
+	str string,
+) string {
 	ret := C.NSString_inst_StringByAppendingPathComponent(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(str),
+		C.createNSStringFromCString(C.CString(str)),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByAppendingPathExtension returns a new string made by appending to the receiver an extension separator followed by a given extension.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1412501-stringbyappendingpathextension?language=objc for details.
 func (x gen_NSString) StringByAppendingPathExtension(
-	str NSStringRef,
-) NSString {
+	str string,
+) string {
 	ret := C.NSString_inst_StringByAppendingPathExtension(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(str),
+		C.createNSStringFromCString(C.CString(str)),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByAppendingString returns a new string made by appending a given string to the receiver.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1412307-stringbyappendingstring?language=objc for details.
 func (x gen_NSString) StringByAppendingString(
-	aString NSStringRef,
-) NSString {
+	aString string,
+) string {
 	ret := C.NSString_inst_StringByAppendingString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(aString),
+		C.createNSStringFromCString(C.CString(aString)),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByPaddingToLengthWithStringStartingAtIndex returns a new string formed from the receiver by either removing characters from the end, or by appending as many occurrences as necessary of a given pad string.
@@ -7660,33 +7671,33 @@ func (x gen_NSString) StringByAppendingString(
 // See https://developer.apple.com/documentation/foundation/nsstring/1416395-stringbypaddingtolength?language=objc for details.
 func (x gen_NSString) StringByPaddingToLengthWithStringStartingAtIndex(
 	newLength NSUInteger,
-	padString NSStringRef,
+	padString string,
 	padIndex NSUInteger,
-) NSString {
+) string {
 	ret := C.NSString_inst_StringByPaddingToLengthWithStringStartingAtIndex(
 		unsafe.Pointer(x.Pointer()),
 		C.ulong(newLength),
-		objc.RefPointer(padString),
+		C.createNSStringFromCString(C.CString(padString)),
 		C.ulong(padIndex),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByReplacingOccurrencesOfStringWithString returns a new string in which all occurrences of a target string in the receiver are replaced by another given string.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1412937-stringbyreplacingoccurrencesofst?language=objc for details.
 func (x gen_NSString) StringByReplacingOccurrencesOfStringWithString(
-	target NSStringRef,
-	replacement NSStringRef,
-) NSString {
+	target string,
+	replacement string,
+) string {
 	ret := C.NSString_inst_StringByReplacingOccurrencesOfStringWithString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(target),
-		objc.RefPointer(replacement),
+		C.createNSStringFromCString(C.CString(target)),
+		C.createNSStringFromCString(C.CString(replacement)),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringsByAppendingPaths returns an array of strings made by separately appending to the receiver each string in a given array.
@@ -7708,13 +7719,13 @@ func (x gen_NSString) StringsByAppendingPaths(
 // See https://developer.apple.com/documentation/foundation/nsstring/1414368-substringfromindex?language=objc for details.
 func (x gen_NSString) SubstringFromIndex(
 	from NSUInteger,
-) NSString {
+) string {
 	ret := C.NSString_inst_SubstringFromIndex(
 		unsafe.Pointer(x.Pointer()),
 		C.ulong(from),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SubstringToIndex returns a new string containing the characters of the receiver up to, but not including, the one at a given index.
@@ -7722,13 +7733,13 @@ func (x gen_NSString) SubstringFromIndex(
 // See https://developer.apple.com/documentation/foundation/nsstring/1408017-substringtoindex?language=objc for details.
 func (x gen_NSString) SubstringToIndex(
 	to NSUInteger,
-) NSString {
+) string {
 	ret := C.NSString_inst_SubstringToIndex(
 		unsafe.Pointer(x.Pointer()),
 		C.ulong(to),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // VariantFittingPresentationWidth returns a string variation suitable for the specified presentation width.
@@ -7736,27 +7747,27 @@ func (x gen_NSString) SubstringToIndex(
 // See https://developer.apple.com/documentation/foundation/nsstring/1413104-variantfittingpresentationwidth?language=objc for details.
 func (x gen_NSString) VariantFittingPresentationWidth(
 	width NSInteger,
-) NSString {
+) string {
 	ret := C.NSString_inst_VariantFittingPresentationWidth(
 		unsafe.Pointer(x.Pointer()),
 		C.long(width),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // WriteToFileAtomicallyEncodingError writes the contents of the receiver to a file at a given path using a given encoding.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1407654-writetofile?language=objc for details.
 func (x gen_NSString) WriteToFileAtomicallyEncodingError(
-	path NSStringRef,
+	path string,
 	useAuxiliaryFile bool,
 	enc NSStringEncoding,
 	error NSErrorRef,
 ) bool {
 	ret := C.NSString_inst_WriteToFileAtomicallyEncodingError(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		convertToObjCBool(useAuxiliaryFile),
 		C.ulong(enc),
 		objc.RefPointer(error),
@@ -7810,111 +7821,111 @@ func (x gen_NSString) Hash() NSUInteger {
 // LowercaseString returns a lowercase representation of the string.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1408467-lowercasestring?language=objc for details.
-func (x gen_NSString) LowercaseString() NSString {
+func (x gen_NSString) LowercaseString() string {
 	ret := C.NSString_inst_LowercaseString(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // LocalizedLowercaseString returns a version of the string with all letters converted to lowercase, taking into account the current locale.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1414125-localizedlowercasestring?language=objc for details.
-func (x gen_NSString) LocalizedLowercaseString() NSString {
+func (x gen_NSString) LocalizedLowercaseString() string {
 	ret := C.NSString_inst_LocalizedLowercaseString(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // UppercaseString an uppercase representation of the string.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1409855-uppercasestring?language=objc for details.
-func (x gen_NSString) UppercaseString() NSString {
+func (x gen_NSString) UppercaseString() string {
 	ret := C.NSString_inst_UppercaseString(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // LocalizedUppercaseString returns a version of the string with all letters converted to uppercase, taking into account the current locale.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1413331-localizeduppercasestring?language=objc for details.
-func (x gen_NSString) LocalizedUppercaseString() NSString {
+func (x gen_NSString) LocalizedUppercaseString() string {
 	ret := C.NSString_inst_LocalizedUppercaseString(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // CapitalizedString returns a capitalized representation of the string.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1416784-capitalizedstring?language=objc for details.
-func (x gen_NSString) CapitalizedString() NSString {
+func (x gen_NSString) CapitalizedString() string {
 	ret := C.NSString_inst_CapitalizedString(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // LocalizedCapitalizedString returns a capitalized representation of the receiver using the current locale.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1414885-localizedcapitalizedstring?language=objc for details.
-func (x gen_NSString) LocalizedCapitalizedString() NSString {
+func (x gen_NSString) LocalizedCapitalizedString() string {
 	ret := C.NSString_inst_LocalizedCapitalizedString(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // DecomposedStringWithCanonicalMapping returns a string made by normalizing the string’s contents using the Unicode Normalization Form D.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1409474-decomposedstringwithcanonicalmap?language=objc for details.
-func (x gen_NSString) DecomposedStringWithCanonicalMapping() NSString {
+func (x gen_NSString) DecomposedStringWithCanonicalMapping() string {
 	ret := C.NSString_inst_DecomposedStringWithCanonicalMapping(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // DecomposedStringWithCompatibilityMapping returns a string made by normalizing the receiver’s contents using the Unicode Normalization Form KD.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1415417-decomposedstringwithcompatibilit?language=objc for details.
-func (x gen_NSString) DecomposedStringWithCompatibilityMapping() NSString {
+func (x gen_NSString) DecomposedStringWithCompatibilityMapping() string {
 	ret := C.NSString_inst_DecomposedStringWithCompatibilityMapping(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // PrecomposedStringWithCanonicalMapping returns a string made by normalizing the string’s contents using the Unicode Normalization Form C.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1412645-precomposedstringwithcanonicalma?language=objc for details.
-func (x gen_NSString) PrecomposedStringWithCanonicalMapping() NSString {
+func (x gen_NSString) PrecomposedStringWithCanonicalMapping() string {
 	ret := C.NSString_inst_PrecomposedStringWithCanonicalMapping(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // PrecomposedStringWithCompatibilityMapping returns a string made by normalizing the receiver’s contents using the Unicode Normalization Form KC.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1412625-precomposedstringwithcompatibili?language=objc for details.
-func (x gen_NSString) PrecomposedStringWithCompatibilityMapping() NSString {
+func (x gen_NSString) PrecomposedStringWithCompatibilityMapping() string {
 	ret := C.NSString_inst_PrecomposedStringWithCompatibilityMapping(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // IntValue returns the integer value of the string.
@@ -7953,12 +7964,12 @@ func (x gen_NSString) BoolValue() bool {
 // Description this NSString object.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1410889-description?language=objc for details.
-func (x gen_NSString) Description() NSString {
+func (x gen_NSString) Description() string {
 	ret := C.NSString_inst_Description(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // FastestEncoding returns the fastest encoding to which the receiver may be converted without loss of information.
@@ -8008,100 +8019,100 @@ func (x gen_NSString) IsAbsolutePath() bool {
 // LastPathComponent returns the last path component of the receiver.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1416528-lastpathcomponent?language=objc for details.
-func (x gen_NSString) LastPathComponent() NSString {
+func (x gen_NSString) LastPathComponent() string {
 	ret := C.NSString_inst_LastPathComponent(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // PathExtension returns the path extension, if any, of the string as interpreted as a path.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1407801-pathextension?language=objc for details.
-func (x gen_NSString) PathExtension() NSString {
+func (x gen_NSString) PathExtension() string {
 	ret := C.NSString_inst_PathExtension(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByAbbreviatingWithTildeInPath returns a new string that replaces the current home directory portion of the current path with a tilde (~) character.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1407943-stringbyabbreviatingwithtildeinp?language=objc for details.
-func (x gen_NSString) StringByAbbreviatingWithTildeInPath() NSString {
+func (x gen_NSString) StringByAbbreviatingWithTildeInPath() string {
 	ret := C.NSString_inst_StringByAbbreviatingWithTildeInPath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByDeletingLastPathComponent returns a new string made by deleting the last path component from the receiver, along with any final path separator.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1411141-stringbydeletinglastpathcomponen?language=objc for details.
-func (x gen_NSString) StringByDeletingLastPathComponent() NSString {
+func (x gen_NSString) StringByDeletingLastPathComponent() string {
 	ret := C.NSString_inst_StringByDeletingLastPathComponent(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByDeletingPathExtension returns a new string made by deleting the extension (if any, and only the last) from the receiver.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1418214-stringbydeletingpathextension?language=objc for details.
-func (x gen_NSString) StringByDeletingPathExtension() NSString {
+func (x gen_NSString) StringByDeletingPathExtension() string {
 	ret := C.NSString_inst_StringByDeletingPathExtension(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByExpandingTildeInPath returns a new string made by expanding the initial component of the receiver to its full path value.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1407716-stringbyexpandingtildeinpath?language=objc for details.
-func (x gen_NSString) StringByExpandingTildeInPath() NSString {
+func (x gen_NSString) StringByExpandingTildeInPath() string {
 	ret := C.NSString_inst_StringByExpandingTildeInPath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByResolvingSymlinksInPath returns a new string made from the receiver by resolving all symbolic links and standardizing path.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1417783-stringbyresolvingsymlinksinpath?language=objc for details.
-func (x gen_NSString) StringByResolvingSymlinksInPath() NSString {
+func (x gen_NSString) StringByResolvingSymlinksInPath() string {
 	ret := C.NSString_inst_StringByResolvingSymlinksInPath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByStandardizingPath returns a new string made by removing extraneous path components from the receiver.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1407194-stringbystandardizingpath?language=objc for details.
-func (x gen_NSString) StringByStandardizingPath() NSString {
+func (x gen_NSString) StringByStandardizingPath() string {
 	ret := C.NSString_inst_StringByStandardizingPath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StringByRemovingPercentEncoding returns a new string made from the receiver by replacing all percent encoded sequences with the matching UTF-8 characters.
 //
 // See https://developer.apple.com/documentation/foundation/nsstring/1409569-stringbyremovingpercentencoding?language=objc for details.
-func (x gen_NSString) StringByRemovingPercentEncoding() NSString {
+func (x gen_NSString) StringByRemovingPercentEncoding() string {
 	ret := C.NSString_inst_StringByRemovingPercentEncoding(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 type NSThreadRef interface {
@@ -8243,23 +8254,23 @@ func (x gen_NSThread) IsMainThread() bool {
 // Name returns the name of the receiver.
 //
 // See https://developer.apple.com/documentation/foundation/nsthread/1414122-name?language=objc for details.
-func (x gen_NSThread) Name() NSString {
+func (x gen_NSThread) Name() string {
 	ret := C.NSThread_inst_Name(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetName returns the name of the receiver.
 //
 // See https://developer.apple.com/documentation/foundation/nsthread/1414122-name?language=objc for details.
 func (x gen_NSThread) SetName(
-	value NSStringRef,
+	value string,
 ) {
 	C.NSThread_inst_SetName(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -8313,11 +8324,11 @@ func NSURL_FromRef(ref objc.Ref) NSURL {
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1410614-urlbyappendingpathcomponent?language=objc for details.
 func (x gen_NSURL) URLByAppendingPathComponent(
-	pathComponent NSStringRef,
+	pathComponent string,
 ) NSURL {
 	ret := C.NSURL_inst_URLByAppendingPathComponent(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(pathComponent),
+		C.createNSStringFromCString(C.CString(pathComponent)),
 	)
 
 	return NSURL_FromPointer(ret)
@@ -8327,12 +8338,12 @@ func (x gen_NSURL) URLByAppendingPathComponent(
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1413953-urlbyappendingpathcomponent?language=objc for details.
 func (x gen_NSURL) URLByAppendingPathComponentIsDirectory(
-	pathComponent NSStringRef,
+	pathComponent string,
 	isDirectory bool,
 ) NSURL {
 	ret := C.NSURL_inst_URLByAppendingPathComponentIsDirectory(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(pathComponent),
+		C.createNSStringFromCString(C.CString(pathComponent)),
 		convertToObjCBool(isDirectory),
 	)
 
@@ -8343,11 +8354,11 @@ func (x gen_NSURL) URLByAppendingPathComponentIsDirectory(
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1417082-urlbyappendingpathextension?language=objc for details.
 func (x gen_NSURL) URLByAppendingPathExtension(
-	pathExtension NSStringRef,
+	pathExtension string,
 ) NSURL {
 	ret := C.NSURL_inst_URLByAppendingPathExtension(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(pathExtension),
+		C.createNSStringFromCString(C.CString(pathExtension)),
 	)
 
 	return NSURL_FromPointer(ret)
@@ -8412,11 +8423,11 @@ func (x gen_NSURL) InitAbsoluteURLWithDataRepresentationRelativeToURL(
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1410301-initfileurlwithpath?language=objc for details.
 func (x gen_NSURL) InitFileURLWithPath(
-	path NSStringRef,
+	path string,
 ) NSURL {
 	ret := C.NSURL_inst_InitFileURLWithPath(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 	)
 
 	return NSURL_FromPointer(ret)
@@ -8426,12 +8437,12 @@ func (x gen_NSURL) InitFileURLWithPath(
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1417505-initfileurlwithpath?language=objc for details.
 func (x gen_NSURL) InitFileURLWithPathIsDirectory(
-	path NSStringRef,
+	path string,
 	isDir bool,
 ) NSURL {
 	ret := C.NSURL_inst_InitFileURLWithPathIsDirectory(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		convertToObjCBool(isDir),
 	)
 
@@ -8442,13 +8453,13 @@ func (x gen_NSURL) InitFileURLWithPathIsDirectory(
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1417932-initfileurlwithpath?language=objc for details.
 func (x gen_NSURL) InitFileURLWithPathIsDirectoryRelativeToURL(
-	path NSStringRef,
+	path string,
 	isDir bool,
 	baseURL NSURLRef,
 ) NSURL {
 	ret := C.NSURL_inst_InitFileURLWithPathIsDirectoryRelativeToURL(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		convertToObjCBool(isDir),
 		objc.RefPointer(baseURL),
 	)
@@ -8460,12 +8471,12 @@ func (x gen_NSURL) InitFileURLWithPathIsDirectoryRelativeToURL(
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1415077-initfileurlwithpath?language=objc for details.
 func (x gen_NSURL) InitFileURLWithPathRelativeToURL(
-	path NSStringRef,
+	path string,
 	baseURL NSURLRef,
 ) NSURL {
 	ret := C.NSURL_inst_InitFileURLWithPathRelativeToURL(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(path),
+		C.createNSStringFromCString(C.CString(path)),
 		objc.RefPointer(baseURL),
 	)
 
@@ -8492,11 +8503,11 @@ func (x gen_NSURL) InitWithDataRepresentationRelativeToURL(
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1413146-initwithstring?language=objc for details.
 func (x gen_NSURL) InitWithString(
-	URLString NSStringRef,
+	URLString string,
 ) NSURL {
 	ret := C.NSURL_inst_InitWithString(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(URLString),
+		C.createNSStringFromCString(C.CString(URLString)),
 	)
 
 	return NSURL_FromPointer(ret)
@@ -8506,12 +8517,12 @@ func (x gen_NSURL) InitWithString(
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1417949-initwithstring?language=objc for details.
 func (x gen_NSURL) InitWithStringRelativeToURL(
-	URLString NSStringRef,
+	URLString string,
 	baseURL NSURLRef,
 ) NSURL {
 	ret := C.NSURL_inst_InitWithStringRelativeToURL(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(URLString),
+		C.createNSStringFromCString(C.CString(URLString)),
 		objc.RefPointer(baseURL),
 	)
 
@@ -8653,12 +8664,12 @@ func (x gen_NSURL) IsFileURL() bool {
 // AbsoluteString returns the URL string for the receiver as an absolute URL. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1409868-absolutestring?language=objc for details.
-func (x gen_NSURL) AbsoluteString() NSString {
+func (x gen_NSURL) AbsoluteString() string {
 	ret := C.NSURL_inst_AbsoluteString(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // AbsoluteURL an absolute URL that refers to the same resource as the receiver. (read-only)
@@ -8686,56 +8697,56 @@ func (x gen_NSURL) BaseURL() NSURL {
 // Fragment returns the fragment identifier, conforming to RFC 1808. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1413775-fragment?language=objc for details.
-func (x gen_NSURL) Fragment() NSString {
+func (x gen_NSURL) Fragment() string {
 	ret := C.NSURL_inst_Fragment(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Host returns the host, conforming to RFC 1808. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1413640-host?language=objc for details.
-func (x gen_NSURL) Host() NSString {
+func (x gen_NSURL) Host() string {
 	ret := C.NSURL_inst_Host(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // LastPathComponent returns the last path component. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1417444-lastpathcomponent?language=objc for details.
-func (x gen_NSURL) LastPathComponent() NSString {
+func (x gen_NSURL) LastPathComponent() string {
 	ret := C.NSURL_inst_LastPathComponent(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Password returns the password conforming to RFC 1808. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1412096-password?language=objc for details.
-func (x gen_NSURL) Password() NSString {
+func (x gen_NSURL) Password() string {
 	ret := C.NSURL_inst_Password(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Path returns the path, conforming to RFC 1808. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1408809-path?language=objc for details.
-func (x gen_NSURL) Path() NSString {
+func (x gen_NSURL) Path() string {
 	ret := C.NSURL_inst_Path(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // PathComponents an array containing the path components. (read-only)
@@ -8752,12 +8763,12 @@ func (x gen_NSURL) PathComponents() NSArray {
 // PathExtension returns the path extension. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1410208-pathextension?language=objc for details.
-func (x gen_NSURL) PathExtension() NSString {
+func (x gen_NSURL) PathExtension() string {
 	ret := C.NSURL_inst_PathExtension(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Port returns the port, conforming to RFC 1808.
@@ -8774,56 +8785,56 @@ func (x gen_NSURL) Port() NSNumber {
 // Query returns the query string, conforming to RFC 1808.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1407543-query?language=objc for details.
-func (x gen_NSURL) Query() NSString {
+func (x gen_NSURL) Query() string {
 	ret := C.NSURL_inst_Query(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // RelativePath returns the relative path, conforming to RFC 1808. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1410263-relativepath?language=objc for details.
-func (x gen_NSURL) RelativePath() NSString {
+func (x gen_NSURL) RelativePath() string {
 	ret := C.NSURL_inst_RelativePath(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // RelativeString returns a string representation of the relative portion of the URL. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1411417-relativestring?language=objc for details.
-func (x gen_NSURL) RelativeString() NSString {
+func (x gen_NSURL) RelativeString() string {
 	ret := C.NSURL_inst_RelativeString(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // ResourceSpecifier returns the resource specifier. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1415309-resourcespecifier?language=objc for details.
-func (x gen_NSURL) ResourceSpecifier() NSString {
+func (x gen_NSURL) ResourceSpecifier() string {
 	ret := C.NSURL_inst_ResourceSpecifier(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Scheme returns the scheme. (read-only)
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1413437-scheme?language=objc for details.
-func (x gen_NSURL) Scheme() NSString {
+func (x gen_NSURL) Scheme() string {
 	ret := C.NSURL_inst_Scheme(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // StandardizedURL returns a copy of the URL with any instances of ".." or "." removed from its path. (read-only)
@@ -8840,12 +8851,12 @@ func (x gen_NSURL) StandardizedURL() NSURL {
 // User returns the user name, conforming to RFC 1808.
 //
 // See https://developer.apple.com/documentation/foundation/nsurl/1418335-user?language=objc for details.
-func (x gen_NSURL) User() NSString {
+func (x gen_NSURL) User() string {
 	ret := C.NSURL_inst_User(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // FilePathURL returns a file path URL that points to the same resource as the URL object. (read-only)
@@ -8951,14 +8962,14 @@ func (x gen_NSURLRequest) InitWithURL(
 //
 // See https://developer.apple.com/documentation/foundation/nsurlrequest/1409376-valueforhttpheaderfield?language=objc for details.
 func (x gen_NSURLRequest) ValueForHTTPHeaderField(
-	field NSStringRef,
-) NSString {
+	field string,
+) string {
 	ret := C.NSURLRequest_inst_ValueForHTTPHeaderField(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(field),
+		C.createNSStringFromCString(C.CString(field)),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Init initializes a new instance of the NSURLRequest class.
@@ -8982,12 +8993,12 @@ func (x gen_NSURLRequest) Init_AsNSURLRequest() NSURLRequest {
 // HTTPMethod returns the HTTP request method.
 //
 // See https://developer.apple.com/documentation/foundation/nsurlrequest/1413030-httpmethod?language=objc for details.
-func (x gen_NSURLRequest) HTTPMethod() NSString {
+func (x gen_NSURLRequest) HTTPMethod() string {
 	ret := C.NSURLRequest_inst_HTTPMethod(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // URL returns the URL being requested.
@@ -9123,11 +9134,11 @@ func NSUserDefaults_FromRef(ref objc.Ref) NSUserDefaults {
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1408648-urlforkey?language=objc for details.
 func (x gen_NSUserDefaults) URLForKey(
-	defaultName NSStringRef,
+	defaultName string,
 ) NSURL {
 	ret := C.NSUserDefaults_inst_URLForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return NSURL_FromPointer(ret)
@@ -9137,11 +9148,11 @@ func (x gen_NSUserDefaults) URLForKey(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1410294-addsuitenamed?language=objc for details.
 func (x gen_NSUserDefaults) AddSuiteNamed(
-	suiteName NSStringRef,
+	suiteName string,
 ) {
 	C.NSUserDefaults_inst_AddSuiteNamed(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(suiteName),
+		C.createNSStringFromCString(C.CString(suiteName)),
 	)
 
 	return
@@ -9151,11 +9162,11 @@ func (x gen_NSUserDefaults) AddSuiteNamed(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1414792-arrayforkey?language=objc for details.
 func (x gen_NSUserDefaults) ArrayForKey(
-	defaultName NSStringRef,
+	defaultName string,
 ) NSArray {
 	ret := C.NSUserDefaults_inst_ArrayForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return NSArray_FromPointer(ret)
@@ -9165,11 +9176,11 @@ func (x gen_NSUserDefaults) ArrayForKey(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1416388-boolforkey?language=objc for details.
 func (x gen_NSUserDefaults) BoolForKey(
-	defaultName NSStringRef,
+	defaultName string,
 ) bool {
 	ret := C.NSUserDefaults_inst_BoolForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -9179,11 +9190,11 @@ func (x gen_NSUserDefaults) BoolForKey(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1409590-dataforkey?language=objc for details.
 func (x gen_NSUserDefaults) DataForKey(
-	defaultName NSStringRef,
+	defaultName string,
 ) NSData {
 	ret := C.NSUserDefaults_inst_DataForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return NSData_FromPointer(ret)
@@ -9193,11 +9204,11 @@ func (x gen_NSUserDefaults) DataForKey(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1408563-dictionaryforkey?language=objc for details.
 func (x gen_NSUserDefaults) DictionaryForKey(
-	defaultName NSStringRef,
+	defaultName string,
 ) NSDictionary {
 	ret := C.NSUserDefaults_inst_DictionaryForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return NSDictionary_FromPointer(ret)
@@ -9240,11 +9251,11 @@ func (x gen_NSUserDefaults) Init_AsNSUserDefaults() NSUserDefaults {
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1409957-initwithsuitename?language=objc for details.
 func (x gen_NSUserDefaults) InitWithSuiteName(
-	suitename NSStringRef,
+	suitename string,
 ) NSUserDefaults {
 	ret := C.NSUserDefaults_inst_InitWithSuiteName(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(suitename),
+		C.createNSStringFromCString(C.CString(suitename)),
 	)
 
 	return NSUserDefaults_FromPointer(ret)
@@ -9254,11 +9265,11 @@ func (x gen_NSUserDefaults) InitWithSuiteName(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1407405-integerforkey?language=objc for details.
 func (x gen_NSUserDefaults) IntegerForKey(
-	defaultName NSStringRef,
+	defaultName string,
 ) NSInteger {
 	ret := C.NSUserDefaults_inst_IntegerForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return NSInteger(ret)
@@ -9268,11 +9279,11 @@ func (x gen_NSUserDefaults) IntegerForKey(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1410095-objectforkey?language=objc for details.
 func (x gen_NSUserDefaults) ObjectForKey(
-	defaultName NSStringRef,
+	defaultName string,
 ) objc.Object {
 	ret := C.NSUserDefaults_inst_ObjectForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return objc.Object_FromPointer(ret)
@@ -9282,11 +9293,11 @@ func (x gen_NSUserDefaults) ObjectForKey(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1408635-objectisforcedforkey?language=objc for details.
 func (x gen_NSUserDefaults) ObjectIsForcedForKey(
-	key NSStringRef,
+	key string,
 ) bool {
 	ret := C.NSUserDefaults_inst_ObjectIsForcedForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -9296,13 +9307,13 @@ func (x gen_NSUserDefaults) ObjectIsForcedForKey(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1416306-objectisforcedforkey?language=objc for details.
 func (x gen_NSUserDefaults) ObjectIsForcedForKeyInDomain(
-	key NSStringRef,
-	domain NSStringRef,
+	key string,
+	domain string,
 ) bool {
 	ret := C.NSUserDefaults_inst_ObjectIsForcedForKeyInDomain(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(key),
-		objc.RefPointer(domain),
+		C.createNSStringFromCString(C.CString(key)),
+		C.createNSStringFromCString(C.CString(domain)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -9312,11 +9323,11 @@ func (x gen_NSUserDefaults) ObjectIsForcedForKeyInDomain(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1412197-persistentdomainforname?language=objc for details.
 func (x gen_NSUserDefaults) PersistentDomainForName(
-	domainName NSStringRef,
+	domainName string,
 ) NSDictionary {
 	ret := C.NSUserDefaults_inst_PersistentDomainForName(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(domainName),
+		C.createNSStringFromCString(C.CString(domainName)),
 	)
 
 	return NSDictionary_FromPointer(ret)
@@ -9340,11 +9351,11 @@ func (x gen_NSUserDefaults) RegisterDefaults(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1411182-removeobjectforkey?language=objc for details.
 func (x gen_NSUserDefaults) RemoveObjectForKey(
-	defaultName NSStringRef,
+	defaultName string,
 ) {
 	C.NSUserDefaults_inst_RemoveObjectForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return
@@ -9354,11 +9365,11 @@ func (x gen_NSUserDefaults) RemoveObjectForKey(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1417339-removepersistentdomainforname?language=objc for details.
 func (x gen_NSUserDefaults) RemovePersistentDomainForName(
-	domainName NSStringRef,
+	domainName string,
 ) {
 	C.NSUserDefaults_inst_RemovePersistentDomainForName(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(domainName),
+		C.createNSStringFromCString(C.CString(domainName)),
 	)
 
 	return
@@ -9368,11 +9379,11 @@ func (x gen_NSUserDefaults) RemovePersistentDomainForName(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1408047-removesuitenamed?language=objc for details.
 func (x gen_NSUserDefaults) RemoveSuiteNamed(
-	suiteName NSStringRef,
+	suiteName string,
 ) {
 	C.NSUserDefaults_inst_RemoveSuiteNamed(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(suiteName),
+		C.createNSStringFromCString(C.CString(suiteName)),
 	)
 
 	return
@@ -9382,11 +9393,11 @@ func (x gen_NSUserDefaults) RemoveSuiteNamed(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1415955-removevolatiledomainforname?language=objc for details.
 func (x gen_NSUserDefaults) RemoveVolatileDomainForName(
-	domainName NSStringRef,
+	domainName string,
 ) {
 	C.NSUserDefaults_inst_RemoveVolatileDomainForName(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(domainName),
+		C.createNSStringFromCString(C.CString(domainName)),
 	)
 
 	return
@@ -9397,12 +9408,12 @@ func (x gen_NSUserDefaults) RemoveVolatileDomainForName(
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1408905-setbool?language=objc for details.
 func (x gen_NSUserDefaults) SetBoolForKey(
 	value bool,
-	defaultName NSStringRef,
+	defaultName string,
 ) {
 	C.NSUserDefaults_inst_SetBoolForKey(
 		unsafe.Pointer(x.Pointer()),
 		convertToObjCBool(value),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return
@@ -9413,12 +9424,12 @@ func (x gen_NSUserDefaults) SetBoolForKey(
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1413614-setinteger?language=objc for details.
 func (x gen_NSUserDefaults) SetIntegerForKey(
 	value NSInteger,
-	defaultName NSStringRef,
+	defaultName string,
 ) {
 	C.NSUserDefaults_inst_SetIntegerForKey(
 		unsafe.Pointer(x.Pointer()),
 		C.long(value),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return
@@ -9429,12 +9440,12 @@ func (x gen_NSUserDefaults) SetIntegerForKey(
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1414067-setobject?language=objc for details.
 func (x gen_NSUserDefaults) SetObjectForKey(
 	value objc.Ref,
-	defaultName NSStringRef,
+	defaultName string,
 ) {
 	C.NSUserDefaults_inst_SetObjectForKey(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(value),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return
@@ -9445,12 +9456,12 @@ func (x gen_NSUserDefaults) SetObjectForKey(
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1408187-setpersistentdomain?language=objc for details.
 func (x gen_NSUserDefaults) SetPersistentDomainForName(
 	domain NSDictionaryRef,
-	domainName NSStringRef,
+	domainName string,
 ) {
 	C.NSUserDefaults_inst_SetPersistentDomainForName(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(domain),
-		objc.RefPointer(domainName),
+		C.createNSStringFromCString(C.CString(domainName)),
 	)
 
 	return
@@ -9461,12 +9472,12 @@ func (x gen_NSUserDefaults) SetPersistentDomainForName(
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1414194-seturl?language=objc for details.
 func (x gen_NSUserDefaults) SetURLForKey(
 	url NSURLRef,
-	defaultName NSStringRef,
+	defaultName string,
 ) {
 	C.NSUserDefaults_inst_SetURLForKey(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(url),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return
@@ -9477,12 +9488,12 @@ func (x gen_NSUserDefaults) SetURLForKey(
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1413720-setvolatiledomain?language=objc for details.
 func (x gen_NSUserDefaults) SetVolatileDomainForName(
 	domain NSDictionaryRef,
-	domainName NSStringRef,
+	domainName string,
 ) {
 	C.NSUserDefaults_inst_SetVolatileDomainForName(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(domain),
-		objc.RefPointer(domainName),
+		C.createNSStringFromCString(C.CString(domainName)),
 	)
 
 	return
@@ -9492,11 +9503,11 @@ func (x gen_NSUserDefaults) SetVolatileDomainForName(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1416414-stringarrayforkey?language=objc for details.
 func (x gen_NSUserDefaults) StringArrayForKey(
-	defaultName NSStringRef,
+	defaultName string,
 ) NSArray {
 	ret := C.NSUserDefaults_inst_StringArrayForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
 	return NSArray_FromPointer(ret)
@@ -9506,14 +9517,14 @@ func (x gen_NSUserDefaults) StringArrayForKey(
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1416700-stringforkey?language=objc for details.
 func (x gen_NSUserDefaults) StringForKey(
-	defaultName NSStringRef,
-) NSString {
+	defaultName string,
+) string {
 	ret := C.NSUserDefaults_inst_StringForKey(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(defaultName),
+		C.createNSStringFromCString(C.CString(defaultName)),
 	)
 
-	return NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // Synchronize waits for any pending asynchronous updates to the defaults database and returns; this method is unnecessary and shouldn't be used.
@@ -9531,11 +9542,11 @@ func (x gen_NSUserDefaults) Synchronize() bool {
 //
 // See https://developer.apple.com/documentation/foundation/nsuserdefaults/1409592-volatiledomainforname?language=objc for details.
 func (x gen_NSUserDefaults) VolatileDomainForName(
-	domainName NSStringRef,
+	domainName string,
 ) NSDictionary {
 	ret := C.NSUserDefaults_inst_VolatileDomainForName(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(domainName),
+		C.createNSStringFromCString(C.CString(domainName)),
 	)
 
 	return NSDictionary_FromPointer(ret)

--- a/core/init.go
+++ b/core/init.go
@@ -53,5 +53,5 @@ func Rect(x, y, w, h float64) NSRect {
 }
 
 func URL(url string) NSURL {
-	return NSURL_Init(url)
+	return NSURL_URLWithString(url)
 }

--- a/coreml/coreml_objc.gen.go
+++ b/coreml/coreml_objc.gen.go
@@ -20,6 +20,17 @@ bool coreml_convertObjCBool(BOOL b) {
 	return false;
 }
 
+// Creates a NSString from a C string
+static void *createNSStringFromCString(char *cString) {
+    return [NSString stringWithCString: cString encoding: NSUTF8StringEncoding];
+}
+
+// Creates a C string from a NSString
+static char *createCStringFromNSString(void *objcString)
+{
+    return [objcString UTF8String];
+}
+
 
 void* MLArrayBatchProvider_type_Alloc() {
 	return [MLArrayBatchProvider
@@ -203,9 +214,9 @@ func MLFeatureValue_Alloc() MLFeatureValue {
 // MLFeatureValue_FeatureValueWithString creates a feature value that contains a string.
 //
 // See https://developer.apple.com/documentation/coreml/mlfeaturevalue/2879343-featurevaluewithstring?language=objc for details.
-func MLFeatureValue_FeatureValueWithString(value core.NSStringRef) MLFeatureValue {
+func MLFeatureValue_FeatureValueWithString(value string) MLFeatureValue {
 	ret := C.MLFeatureValue_type_FeatureValueWithString(
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return MLFeatureValue_FromPointer(ret)
@@ -394,11 +405,11 @@ func (x gen_MLDictionaryFeatureProvider) InitWithDictionaryError(
 //
 // See https://developer.apple.com/documentation/coreml/mldictionaryfeatureprovider/2881954-objectforkeyedsubscript?language=objc for details.
 func (x gen_MLDictionaryFeatureProvider) ObjectForKeyedSubscript(
-	featureName core.NSStringRef,
+	featureName string,
 ) MLFeatureValue {
 	ret := C.MLDictionaryFeatureProvider_inst_ObjectForKeyedSubscript(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(featureName),
+		C.createNSStringFromCString(C.CString(featureName)),
 	)
 
 	return MLFeatureValue_FromPointer(ret)
@@ -498,12 +509,12 @@ func (x gen_MLFeatureValue) IsUndefined() bool {
 // StringValue returns the underlying string of the feature value.
 //
 // See https://developer.apple.com/documentation/coreml/mlfeaturevalue/2879349-stringvalue?language=objc for details.
-func (x gen_MLFeatureValue) StringValue() core.NSString {
+func (x gen_MLFeatureValue) StringValue() string {
 	ret := C.MLFeatureValue_inst_StringValue(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // DictionaryValue returns the underlying dictionary of the feature value.

--- a/examples/userdefaults/main.go
+++ b/examples/userdefaults/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	ud := core.NSUserDefaults_StandardUserDefaults()
-	ud.SetURLForKey(core.URL("https://github.com/progrium/macdriver"), core.String("macdriver"))
-	u := ud.URLForKey(core.String("macdriver"))
+	ud.SetURLForKey(core.URL("https://github.com/progrium/macdriver"), "macdriver")
+	u := ud.URLForKey("macdriver")
 	fmt.Println("looked up 'macdriver' key in NSUserDefaults and got:", u)
 }

--- a/gen/convert.go
+++ b/gen/convert.go
@@ -70,6 +70,7 @@ func processClassSchema(pkg *GoPackage, s *schema.Schema, imports []PackageConte
 			Unavailable: m.Unavailable,
 		}
 
+		checkMethodForStringException(&cb, m.Name, &wrapper)
 		pkg.ClassMsgSendWrappers = append(pkg.ClassMsgSendWrappers, msg)
 		pkg.CGoWrapperFuncs = append(pkg.CGoWrapperFuncs, wrapper)
 	})
@@ -79,6 +80,7 @@ func processClassSchema(pkg *GoPackage, s *schema.Schema, imports []PackageConte
 		method := cb.instanceMethod(m)
 		msg := cb.msgSend(m, false)
 
+		checkMethodForStringException(&cb, m.Name, &method)
 		classDef.InstanceMethods = append(classDef.InstanceMethods, method)
 		pkg.MsgSendWrappers = append(pkg.MsgSendWrappers, msg)
 		// handle typed init methods
@@ -122,3 +124,66 @@ func formatComment(m schema.Method, ident string) string {
 	return result.String()
 
 }
+
+
+/*
+ Not every class method can have their NSString argument and/or
+ NSString return value translated into a Go string. For these
+ exceptions we use this table to filter them out.
+ */
+
+type StringExceptionList struct {
+	Class string
+	Method string
+}
+
+var exceptionList = []StringExceptionList {
+	{"NSString", "alloc"},
+	{"NSString", "init"},
+	{"NSString", "initWithBytes:length:encoding:"},
+	{"NSString", "initWithBytesNoCopy:length:encoding:freeWhenDone:"},
+	{"NSString", "initWithCharacters:length:"},
+	{"NSString", "initWithCharactersNoCopy:length:freeWhenDone:"},
+	{"NSString", "initWithString:"},
+	{"NSString", "initWithCString:encoding:"},
+	{"NSString", "initWithUTF8String:"},
+	{"NSString", "initWithFormat:"},
+	{"NSString", "initWithFormat:arguments:"},
+	{"NSString", "initWithFormat:locale:"},
+	{"NSString", "initWithFormat:locale:arguments:"},
+	{"NSString", "initWithData:encoding:"},
+	{"NSString", "stringWithString:"},
+	{"NSString", "string"},
+}
+
+// Searches the exception list for the specified method
+// Returns true if found and false otherwise
+func methodInExceptionList(className string, methodName string) bool {
+	for _, entry := range exceptionList {
+		if entry.Class == className && entry.Method == methodName {
+			return true
+		}
+	}
+	return false
+}
+
+
+// Does the work of changing types from string to NSString
+// cb: a classBuilder pointer
+// objcMethodName: a string that represents an objective-c method signature
+// method: a pointer to a MethodDef
+func checkMethodForStringException(cb *classBuilder, objcMethodName string, method *MethodDef) {
+	if methodInExceptionList(cb.Class.Name, objcMethodName) {
+		// Currently there is no known case of a method needing its argument
+		// to be a NSString. If such a case is found then the code to handle
+		// this case would go here.
+		// The StringExceptionList struct would need to be updated to include
+		// a field called "ChangeArgs bool" that would indicate if the
+		// arguments need to be changed.
+		
+		// Change the return type
+		method.WrappedFunc.Returns[0].Type = "NSString"
+		method.WrappedFunc.Returns[0].FromCGoFmt = "NSString_FromPointer(%s)"
+	}
+}
+

--- a/gen/lookup.go
+++ b/gen/lookup.go
@@ -43,6 +43,17 @@ func (cb *classBuilder) mapClass(name string) *typeMapping {
 	if !found {
 		return nil
 	}
+	
+	if name == "NSString" {
+		return &typeMapping{
+			GoType:          "string",
+			GoSimpleRefType: "string",
+			CType:           "void*",
+			FromCGoFmt:      "C.GoString(C.createCStringFromNSString(%s))",  // Convert return value from NSString to Go string
+			ToCGoFmt:        "C.createNSStringFromCString(C.CString(%s))",	 // Convert argument from Go string to NSString
+		}
+	}
+	
 	return &typeMapping{
 		GoType:          pkgPrefix + name,
 		GoSimpleRefType: pkgPrefix + name + "Ref",

--- a/gen/template/package.tmpl
+++ b/gen/template/package.tmpl
@@ -30,6 +30,17 @@ bool {{.Name}}_convertObjCBool(BOOL b) {
 	return false;
 }
 
+// Creates a NSString from a C string
+static void *createNSStringFromCString(char *cString) {
+    return [NSString stringWithCString: cString encoding: NSUTF8StringEncoding];
+}
+
+// Creates a C string from a NSString
+static char *createCStringFromNSString(void *objcString)
+{
+    return [objcString UTF8String];
+}
+
 {{range .ClassMsgSendWrappers}}
 {{.Return}} {{.Name}}(
 	{{- range $idx, $_ := .Selector -}}{{- if .Arg -}}

--- a/vision/vision_objc.gen.go
+++ b/vision/vision_objc.gen.go
@@ -20,6 +20,17 @@ bool vision_convertObjCBool(BOOL b) {
 	return false;
 }
 
+// Creates a NSString from a C string
+static void *createNSStringFromCString(char *cString) {
+    return [NSString stringWithCString: cString encoding: NSUTF8StringEncoding];
+}
+
+// Creates a C string from a NSString
+static char *createCStringFromNSString(void *objcString)
+{
+    return [objcString UTF8String];
+}
+
 
 void* VNClassifyImageRequest_type_Alloc() {
 	return [VNClassifyImageRequest

--- a/webkit/WKWebView.go
+++ b/webkit/WKWebView.go
@@ -20,6 +20,6 @@ func (wv WKWebView) Reload(sender objc.Object) {
 	wv.Reload_(sender)
 }
 
-func (wv WKWebView) LoadHTMLString(html core.NSString, url core.NSURL) {
+func (wv WKWebView) LoadHTMLString(html string, url core.NSURL) {
 	wv.LoadHTMLStringBaseURL(html, url)
 }

--- a/webkit/webkit_objc.gen.go
+++ b/webkit/webkit_objc.gen.go
@@ -21,6 +21,17 @@ bool webkit_convertObjCBool(BOOL b) {
 	return false;
 }
 
+// Creates a NSString from a C string
+static void *createNSStringFromCString(char *cString) {
+    return [NSString stringWithCString: cString encoding: NSUTF8StringEncoding];
+}
+
+// Creates a C string from a NSString
+static char *createCStringFromNSString(void *objcString)
+{
+    return [objcString UTF8String];
+}
+
 
 void* WKNavigation_type_Alloc() {
 	return [WKNavigation
@@ -503,9 +514,9 @@ func WKWebView_Alloc() WKWebView {
 // WKWebView_HandlesURLScheme returns a Boolean value that indicates whether WebKit natively supports resources with the specified URL scheme.
 //
 // See https://developer.apple.com/documentation/webkit/wkwebview/2875370-handlesurlscheme?language=objc for details.
-func WKWebView_HandlesURLScheme(urlScheme core.NSStringRef) bool {
+func WKWebView_HandlesURLScheme(urlScheme string) bool {
 	ret := C.WKWebView_type_HandlesURLScheme(
-		objc.RefPointer(urlScheme),
+		C.createNSStringFromCString(C.CString(urlScheme)),
 	)
 
 	return convertObjCBoolToGo(ret)
@@ -602,12 +613,12 @@ func (x gen_WKUserScript) Init_AsWKUserScript() WKUserScript {
 // Source returns the script’s source code.
 //
 // See https://developer.apple.com/documentation/webkit/wkuserscript/1537787-source?language=objc for details.
-func (x gen_WKUserScript) Source() core.NSString {
+func (x gen_WKUserScript) Source() string {
 	ret := C.WKUserScript_inst_Source(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // IsForMainFrameOnly returns a Boolean value that indicates whether to inject the script into the main frame or all frames.
@@ -711,15 +722,15 @@ func (x gen_WKWebView) InitWithFrameConfiguration(
 // See https://developer.apple.com/documentation/webkit/wkwebview/1415011-loaddata?language=objc for details.
 func (x gen_WKWebView) LoadDataMIMETypeCharacterEncodingNameBaseURL(
 	data core.NSDataRef,
-	MIMEType core.NSStringRef,
-	characterEncodingName core.NSStringRef,
+	MIMEType string,
+	characterEncodingName string,
 	baseURL core.NSURLRef,
 ) WKNavigation {
 	ret := C.WKWebView_inst_LoadDataMIMETypeCharacterEncodingNameBaseURL(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(data),
-		objc.RefPointer(MIMEType),
-		objc.RefPointer(characterEncodingName),
+		C.createNSStringFromCString(C.CString(MIMEType)),
+		C.createNSStringFromCString(C.CString(characterEncodingName)),
 		objc.RefPointer(baseURL),
 	)
 
@@ -762,12 +773,12 @@ func (x gen_WKWebView) LoadFileURLAllowingReadAccessToURL(
 //
 // See https://developer.apple.com/documentation/webkit/wkwebview/1415004-loadhtmlstring?language=objc for details.
 func (x gen_WKWebView) LoadHTMLStringBaseURL(
-	string core.NSStringRef,
+	string string,
 	baseURL core.NSURLRef,
 ) WKNavigation {
 	ret := C.WKWebView_inst_LoadHTMLStringBaseURL(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(string),
+		C.createNSStringFromCString(C.CString(string)),
 		objc.RefPointer(baseURL),
 	)
 
@@ -793,12 +804,12 @@ func (x gen_WKWebView) LoadRequest(
 // See https://developer.apple.com/documentation/webkit/wkwebview/3763095-loadsimulatedrequest?language=objc for details.
 func (x gen_WKWebView) LoadSimulatedRequestResponseHTMLString(
 	request core.NSURLRequestRef,
-	string core.NSStringRef,
+	string string,
 ) WKNavigation {
 	ret := C.WKWebView_inst_LoadSimulatedRequestResponseHTMLString(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(request),
-		objc.RefPointer(string),
+		C.createNSStringFromCString(C.CString(string)),
 	)
 
 	return WKNavigation_FromPointer(ret)
@@ -972,12 +983,12 @@ func (x gen_WKWebView) IsLoading() bool {
 // Title returns the page title.
 //
 // See https://developer.apple.com/documentation/webkit/wkwebview/1415015-title?language=objc for details.
-func (x gen_WKWebView) Title() core.NSString {
+func (x gen_WKWebView) Title() string {
 	ret := C.WKWebView_inst_Title(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // URL returns the URL for the current webpage.
@@ -994,23 +1005,23 @@ func (x gen_WKWebView) URL() core.NSURL {
 // MediaType returns the media type for the contents of the web view.
 //
 // See https://developer.apple.com/documentation/webkit/wkwebview/3516410-mediatype?language=objc for details.
-func (x gen_WKWebView) MediaType() core.NSString {
+func (x gen_WKWebView) MediaType() string {
 	ret := C.WKWebView_inst_MediaType(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetMediaType returns the media type for the contents of the web view.
 //
 // See https://developer.apple.com/documentation/webkit/wkwebview/3516410-mediatype?language=objc for details.
 func (x gen_WKWebView) SetMediaType(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.WKWebView_inst_SetMediaType(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -1019,23 +1030,23 @@ func (x gen_WKWebView) SetMediaType(
 // CustomUserAgent returns the custom user agent string.
 //
 // See https://developer.apple.com/documentation/webkit/wkwebview/1414950-customuseragent?language=objc for details.
-func (x gen_WKWebView) CustomUserAgent() core.NSString {
+func (x gen_WKWebView) CustomUserAgent() string {
 	ret := C.WKWebView_inst_CustomUserAgent(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetCustomUserAgent returns the custom user agent string.
 //
 // See https://developer.apple.com/documentation/webkit/wkwebview/1414950-customuseragent?language=objc for details.
 func (x gen_WKWebView) SetCustomUserAgent(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.WKWebView_inst_SetCustomUserAgent(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -1223,12 +1234,12 @@ func WKWebViewConfiguration_FromRef(ref objc.Ref) WKWebViewConfiguration {
 // See https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/2875766-seturlschemehandler?language=objc for details.
 func (x gen_WKWebViewConfiguration) SetURLSchemeHandlerForURLScheme(
 	urlSchemeHandler objc.Ref,
-	urlScheme core.NSStringRef,
+	urlScheme string,
 ) {
 	C.WKWebViewConfiguration_inst_SetURLSchemeHandlerForURLScheme(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(urlSchemeHandler),
-		objc.RefPointer(urlScheme),
+		C.createNSStringFromCString(C.CString(urlScheme)),
 	)
 
 	return
@@ -1238,11 +1249,11 @@ func (x gen_WKWebViewConfiguration) SetURLSchemeHandlerForURLScheme(
 //
 // See https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/2875767-urlschemehandlerforurlscheme?language=objc for details.
 func (x gen_WKWebViewConfiguration) UrlSchemeHandlerForURLScheme(
-	urlScheme core.NSStringRef,
+	urlScheme string,
 ) objc.Object {
 	ret := C.WKWebViewConfiguration_inst_UrlSchemeHandlerForURLScheme(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(urlScheme),
+		C.createNSStringFromCString(C.CString(urlScheme)),
 	)
 
 	return objc.Object_FromPointer(ret)
@@ -1269,23 +1280,23 @@ func (x gen_WKWebViewConfiguration) Init_AsWKWebViewConfiguration() WKWebViewCon
 // ApplicationNameForUserAgent returns the app name that appears in the user agent string.
 //
 // See https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/1395665-applicationnameforuseragent?language=objc for details.
-func (x gen_WKWebViewConfiguration) ApplicationNameForUserAgent() core.NSString {
+func (x gen_WKWebViewConfiguration) ApplicationNameForUserAgent() string {
 	ret := C.WKWebViewConfiguration_inst_ApplicationNameForUserAgent(
 		unsafe.Pointer(x.Pointer()),
 	)
 
-	return core.NSString_FromPointer(ret)
+	return C.GoString(C.createCStringFromNSString(ret))
 }
 
 // SetApplicationNameForUserAgent returns the app name that appears in the user agent string.
 //
 // See https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/1395665-applicationnameforuseragent?language=objc for details.
 func (x gen_WKWebViewConfiguration) SetApplicationNameForUserAgent(
-	value core.NSStringRef,
+	value string,
 ) {
 	C.WKWebViewConfiguration_inst_SetApplicationNameForUserAgent(
 		unsafe.Pointer(x.Pointer()),
-		objc.RefPointer(value),
+		C.createNSStringFromCString(C.CString(value)),
 	)
 
 	return
@@ -1513,12 +1524,12 @@ func WKPreferences_FromRef(ref objc.Ref) WKPreferences {
 // SetValueForKey is undocumented.
 func (x gen_WKPreferences) SetValueForKey(
 	value objc.Ref,
-	key core.NSStringRef,
+	key string,
 ) {
 	C.WKPreferences_inst_SetValueForKey(
 		unsafe.Pointer(x.Pointer()),
 		objc.RefPointer(value),
-		objc.RefPointer(key),
+		C.createNSStringFromCString(C.CString(key)),
 	)
 
 	return


### PR DESCRIPTION
This makes the using Apple's frameworks much more easier. No longer will we be required to convert from a Go string to a NSString. This patch makes using Go strings possible for all the API that requires a NSString. There is a table for exceptions to this change so methods that should return a NSString can be specified and allowed to continue returning NSString.