### PR TITLE
Print statistics about the build process at the end of building

### DIFF
--- a/gen/cmd/loader.go
+++ b/gen/cmd/loader.go
@@ -153,6 +153,7 @@ func generate(basePackage string, packages []pkg) error {
 			Classes: definedClasses(schemas),
 		})
 	}
+	gen.PrintStats()
 	return nil
 }
 

--- a/gen/convert.go
+++ b/gen/convert.go
@@ -78,6 +78,7 @@ func processClassSchema(pkg *GoPackage, s *schema.Schema, imports []PackageConte
 		checkMethodForStringException(&cb, m.Name, &wrapper)
 		pkg.ClassMsgSendWrappers = append(pkg.ClassMsgSendWrappers, msg)
 		pkg.CGoWrapperFuncs = append(pkg.CGoWrapperFuncs, wrapper)
+		IncrementSuccess()
 	})
 	cb.EachInstanceMethod(func(m schema.Method) {
 		defer ignoreIfUnimplemented(fmt.Sprintf("%s.%s", s.Class.Name, m.Name))
@@ -95,7 +96,7 @@ func processClassSchema(pkg *GoPackage, s *schema.Schema, imports []PackageConte
 			method.Description = formatComment(m, method.Name)
 			classDef.InstanceMethods = append(classDef.InstanceMethods, method)
 		}
-
+		IncrementSuccess()
 	})
 
 	return classDef, nil

--- a/gen/convert.go
+++ b/gen/convert.go
@@ -98,7 +98,7 @@ func processClassSchema(pkg *GoPackage, s *schema.Schema, imports []PackageConte
 		}
 		IncrementSuccess()
 	})
-
+	IncrementClasses() // for statistical purposes
 	return classDef, nil
 }
 

--- a/gen/statistics.go
+++ b/gen/statistics.go
@@ -11,6 +11,7 @@ import "fmt"
 // keeps track of count
 var successes int
 var skipped int
+var classes int
 
 // increments the successes variable when a function is successfully wrapped
 func IncrementSuccess() {
@@ -22,10 +23,17 @@ func IncrementSkipped() {
 	skipped++
 }
 
+func IncrementClasses() {
+	classes++
+}
+
 // prints statistics about the build process
 func PrintStats() {
 	fmt.Println("\n\nStatistics:")
 	fmt.Println("--------------------------------------------------")
-	fmt.Printf("Successfully wrapped methods: %8d", successes)
-	fmt.Printf("\nSkipped methods: %21d\n\n", skipped)
+	fmt.Printf("%-33s %d", "Wrapped methods:", successes)
+	fmt.Printf("\n%-33s %d", "Skipped methods:", skipped)
+	fmt.Printf("\n%-33s %.2f%%", "Percent wrapped:", float64(successes)/float64(successes + skipped)*100)
+	fmt.Printf("\n%-33s %.2f%%", "Percent skipped:", float64(skipped)/float64(successes + skipped)*100)
+	fmt.Printf("\n%-33s %d\n\n", "Classes:", classes)
 }

--- a/gen/statistics.go
+++ b/gen/statistics.go
@@ -1,0 +1,31 @@
+/*
+ * File: statistics.go
+ * Description: displays statistics about the build proccess.
+ */
+
+
+package gen
+
+import "fmt"
+
+// keeps track of count
+var successes int
+var skipped int
+
+// increments the successes variable when a function is successfully wrapped
+func IncrementSuccess() {
+	successes++
+}
+
+// increments the skipped variable when a function is skipped
+func IncrementSkipped() {
+	skipped++
+}
+
+// prints statistics about the build process
+func PrintStats() {
+	fmt.Println("\n\nStatistics:")
+	fmt.Println("--------------------------------------------------")
+	fmt.Printf("Successfully wrapped methods: %8d", successes)
+	fmt.Printf("\nSkipped methods: %21d\n\n", skipped)
+}

--- a/gen/unimplemented.go
+++ b/gen/unimplemented.go
@@ -30,4 +30,5 @@ func ignoreIfUnimplemented(key string) {
 		panic(err)
 	}
 	log.Printf("skip %s: %s", key, err)
+	IncrementSkipped()
 }


### PR DESCRIPTION
This will print statistics about the build process at the end of building.

It will look like this:

```
Statistics:
--------------------------------------------------
Successfully wrapped methods:     2245
Skipped methods:                  1186

```
