### PR TITLE
add older supported mac versions to github actions test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [stable, oldstable]
+        go-version: [oldstable]
         os: [macos-11, macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,13 @@
 on: [push, pull_request]
 name: Test
+env:
+  CGO_CFLAGS: -w
 jobs:
   test:
     strategy:
       matrix:
         go-version: [stable, oldstable]
-        os: [macos-13]
+        os: [macos-11, macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
@@ -15,4 +17,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Test
-      run: go test -v ./...
+      run: |
+        TAGS=${{ matrix.os }}
+        TAGS=${TAGS//-} # remove dash
+        go test -tags $TAGS -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 name: Test
 env:
   CGO_CFLAGS: -w

--- a/coreml/MLArrayBatchProvider.go
+++ b/coreml/MLArrayBatchProvider.go
@@ -1,3 +1,5 @@
+//go:build !macos12 && !macos11
+
 package coreml
 
 type MLArrayBatchProvider struct{ gen_MLArrayBatchProvider }

--- a/coreml/MLDictionaryFeatureProvider.go
+++ b/coreml/MLDictionaryFeatureProvider.go
@@ -1,3 +1,5 @@
+//go:build !macos12 && !macos11
+
 package coreml
 
 type MLDictionaryFeatureProvider struct {

--- a/coreml/MLFeatureValue.go
+++ b/coreml/MLFeatureValue.go
@@ -1,3 +1,5 @@
+//go:build !macos12 && !macos11
+
 package coreml
 
 type MLFeatureValue struct{ gen_MLFeatureValue }

--- a/coreml/MLModel.go
+++ b/coreml/MLModel.go
@@ -1,3 +1,5 @@
+//go:build !macos12 && !macos11
+
 package coreml
 
 type MLModel struct{ gen_MLModel }

--- a/coreml/MLModelAsset.go
+++ b/coreml/MLModelAsset.go
@@ -1,3 +1,5 @@
+//go:build !macos12 && !macos11
+
 package coreml
 
 type MLModelAsset struct{ gen_MLModelAsset }

--- a/coreml/MLModelCollection.go
+++ b/coreml/MLModelCollection.go
@@ -1,3 +1,5 @@
+//go:build !macos12 && !macos11
+
 package coreml
 
 type MLModelCollection struct{ gen_MLModelCollection }

--- a/coreml/coreml_objc.gen.go
+++ b/coreml/coreml_objc.gen.go
@@ -1,9 +1,12 @@
+//go:build !macos12 && !macos11
+
 package coreml
 
 import (
+	"unsafe"
+
 	core "github.com/progrium/macdriver/core"
 	"github.com/progrium/macdriver/objc"
-	"unsafe"
 )
 
 /*

--- a/coreml/doc.go
+++ b/coreml/doc.go
@@ -1,2 +1,4 @@
+//go:build !macos12 && !macos11
+
 // Package coreml exposes the CoreML Framework.
 package coreml


### PR DESCRIPTION
This also introduces experimental build tags for specific versions of macOS. Currently using them to not build `coreml` package earlier than `macos-13`. Even though the framework is available, one of the classes is not and we don't have per class ability to tag yet. This allows tests to run and pass in older versions.