### PR TITLE
Add helper package to easier use of Cocoa API with Go

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -1,0 +1,46 @@
+package helper
+
+import "runtime"
+import "reflect"
+import "strings"
+import "fmt"
+import "github.com/progrium/macdriver/objc"
+import "github.com/progrium/macdriver/cocoa"
+
+
+// Adds the ActionHelper class to the objective-c system
+func init() {
+	newClass := objc.NewClass("ActionHelper", "NSObject")
+	objc.RegisterClass(newClass)
+}
+
+
+// Creates a unique method name using a control and a Go function
+func createActionName(control interface{}, callback func(sender interface{})) string {
+	actionName := runtime.FuncForPC(reflect.ValueOf(callback).Pointer()).Name()
+	actionName = fmt.Sprintf("%s%s", actionName, control)
+	
+	// remove any characters that should not be in a method's name
+	actionName = strings.ReplaceAll(actionName, " ", "") // remove space
+	actionName = strings.ReplaceAll(actionName, ":", "") // remove middle colon
+	actionName = strings.ReplaceAll(actionName, "<", "") // remove <
+	actionName = strings.ReplaceAll(actionName, ">", "") // remove >
+	actionName = actionName + ":"						 // add colon at end
+	return actionName
+}
+
+
+// Sets a control's action and target for use with a Go function
+// Input 1: control - NSControl subclass
+// Input 2: callback - a Go function that has one argument of interface{}
+func SetAction(control cocoa.NSControlRef, callback func(sender interface{})) {
+	actionClass := objc.Get("ActionHelper")
+	actionName := createActionName(control, callback)
+	actionClass.AddMethod(actionName, func(sender objc.Object){
+		callback(control)
+	})
+	theControl := cocoa.NSControl_FromRef(control)
+	actionObj := actionClass.Alloc()
+	theControl.SetTarget(actionObj)
+	theControl.SetAction(objc.Sel(actionName))
+}


### PR DESCRIPTION
This package is made to help the user more easily use the Cocoa API with Go. Currently it adds the SetAction() method. This method makes it very easy to set a control's action to a Go function. One feature that the current implementation of NSControl's SetAction() method doesn't implement that this method does is the ability to send an Action method the sender of the action. This is standard behavior in Objective-C. 

This program can be used to test out this pull request. It displays a window with several controls. The user can click on a control and see a message printed to the terminal.

<img width="812" alt="program" src="https://github.com/progrium/macdriver/assets/19289541/6105913e-b052-47cb-b214-2fa706f24d2f">


```
package main

import "github.com/progrium/macdriver/cocoa"
import "github.com/progrium/macdriver/objc"
import "github.com/progrium/macdriver/core"
import "github.com/progrium/macdriver/helper"
import "fmt"

func main() {
	
	app := cocoa.NSApp_WithDidLaunch(func(n objc.Object) {
			win := cocoa.NSWindow_New()
			win.SetTitle("NSButton")
			winRect := core.NSMakeRect(20, 20, 700, 400)
			win.SetFrameDisplay(winRect, true)
			win.MakeKeyAndOrderFront(nil)

			/* NSSlider code */
			slider := cocoa.NSSlider_Alloc()
			sliderRect := core.NSMakeRect(30, 320, 60, 20)
			slider.InitWithFrame(sliderRect)
			//slider.SetMaxValue(100) // Needs the mapType() patch
			win.ContentView().AddSubview(slider)
			helper.SetAction(slider, doSliderAction)
			
			/* Textfield code */
			field := cocoa.NSTextField_Alloc()
			fieldRect := core.NSMakeRect(120, 320, 200, 20)
			field.InitWithFrame(fieldRect)
			field.SetStringValue("Click then push enter for action")
			win.ContentView().AddSubview(field)
			helper.SetAction(field, doTextFieldAction)
			
			/* NSButton code */
			buttonWidth := 70.0
			buttonHeight := 30.0
			for y := 0; y < 10; y++ {
				for x := 0; x < 10; x++ {
					rect := core.NSMakeRect(float64(x) * buttonWidth, float64(y) * buttonHeight, buttonWidth, buttonHeight)
					button := cocoa.NSButton_Alloc()
					button.InitWithFrame(rect)
					newTitle := fmt.Sprintf("%dx%d", x, y)
					button.SetTitle(newTitle)
					helper.SetAction(button, doButtonAction)
					win.ContentView().AddSubview(button)
				}
			}
		})

		app.SetActivationPolicy(cocoa.NSApplicationActivationPolicyRegular)
		app.ActivateIgnoringOtherApps(true)
		app.Run()
}

// all the buttons' action method
func doButtonAction(sender any) {
	button := sender.(cocoa.NSButton)
	fmt.Println("button pressed:", button.Title())
}

// the slider's action method
func doSliderAction(sender any) {
	slider := sender.(cocoa.NSSlider)
	fmt.Println("Slider:", slider.IntValue())
}

// the textfield's action method
func doTextFieldAction(sender any) {
	field := sender.(cocoa.NSTextField)
	fmt.Println("TextField:", field.StringValue())
}
```
