### PR TITLE
fix to webkit callback needing string or nil value

### DIFF
--- a/generate/codegen/gen_protocol.go
+++ b/generate/codegen/gen_protocol.go
@@ -20,6 +20,10 @@ type Protocol struct {
 	Description string
 	DocURL      string
 
+	SkipInterface bool
+	SkipWrapper   bool
+	SkipDelegate  bool
+
 	init bool
 }
 
@@ -104,18 +108,23 @@ func (p *Protocol) GoImports() set.Set[string] {
 func (p *Protocol) WriteGoCode(w *CodeWriter) {
 	w.WriteLine("")
 
-	// Protocol Interface
-	p.writeProtocolInterface(w)
+	if !p.SkipInterface {
+		p.writeProtocolInterface(w)
+	}
 
 	// Delegate Prototol impl struct
 	w.WriteLine("")
-	if strings.Contains(p.Type.GName, "Delegate") {
+
+	if strings.Contains(p.Type.GName, "Delegate") && !p.SkipDelegate {
 		p.writeDelegateStruct(w)
 	}
 
-	// Protocol Wrapper
 	w.WriteLine("")
-	p.writeProtocolWrapperStruct(w)
+
+	if !p.SkipWrapper {
+		p.writeProtocolWrapperStruct(w)
+	}
+
 }
 
 func (p *Protocol) writeProtocolInterface(w *CodeWriter) {

--- a/generate/members.go
+++ b/generate/members.go
@@ -217,6 +217,13 @@ func (db *Generator) Members(fw string, sym Symbol, covariantTypes []string) (pr
 					//Required:    ??,
 				}
 
+				// skip if defined in custom
+				qualifiedName := fmt.Sprintf("%s#%s", modules.TrimPrefix(sym.Name), gm.GoFuncName())
+				if db.customMethods.Contains(qualifiedName) {
+					log.Printf("skipping custom defined method '%s'\n", qualifiedName)
+					continue
+				}
+
 				// handle name conflicts
 				sel := gm.Selector()
 				goSel := gm.ProtocolGoFuncName()

--- a/macos/_examples/menu/main.go
+++ b/macos/_examples/menu/main.go
@@ -59,14 +59,14 @@ func setMainMenu(app appkit.Application) {
 	menu := appkit.Menu_InitWithTitle("main")
 	app.SetMainMenu(menu)
 
-	mainMenuItem := appkit.NewMenuItemWithSelector(" ", " ", objc.Selector{})
+	mainMenuItem := appkit.NewMenuItemWithSelector("", "", objc.Selector{})
 	mainMenuMenu := appkit.Menu_InitWithTitle("App")
 	mainMenuMenu.AddItem(appkit.NewMenuItemWithAction("Hide", "h", func(sender objc.Object) { app.Hide(nil) }))
 	mainMenuMenu.AddItem(appkit.NewMenuItemWithAction("Quit", "q", func(sender objc.Object) { app.Terminate(nil) }))
 	mainMenuItem.SetSubmenu(mainMenuMenu)
 	menu.AddItem(mainMenuItem)
 
-	testMenuItem := appkit.NewMenuItemWithSelector(" ", " ", objc.Selector{})
+	testMenuItem := appkit.NewMenuItemWithSelector("", "", objc.Selector{})
 	testMenu := appkit.Menu_InitWithTitle("Edit")
 	testMenu.AddItem(appkit.NewMenuItemWithSelector("Select All", "a", objc.Sel("selectAll:")))
 	// missing symbol?

--- a/macos/_examples/webview/main.go
+++ b/macos/_examples/webview/main.go
@@ -16,6 +16,10 @@ import (
 //go:embed assets
 var assetsFS embed.FS
 
+func init() {
+	runtime.LockOSThread()
+}
+
 func main() {
 	app := appkit.ApplicationClass.SharedApplication()
 	w := appkit.NewWindowWithSize(600, 400)

--- a/macos/_examples/widgets/main.go
+++ b/macos/_examples/widgets/main.go
@@ -105,7 +105,7 @@ func main() {
 	tf.SetFrame(rectOf(10, 100, 150, 25))
 
 	// label
-	label := appkit.NewLabel(" ")
+	label := appkit.NewLabel("")
 	label.SetFrame(rectOf(170, 100, 150, 25))
 	w.ContentView().AddSubview(label)
 	tfd := &appkit.TextFieldDelegate{}

--- a/macos/webkit/script_message_handler_with_reply.gen.go
+++ b/macos/webkit/script_message_handler_with_reply.gen.go
@@ -1,32 +1,3 @@
 // AUTO-GENERATED CODE, DO NOT MODIFY
 
 package webkit
-
-import (
-	"github.com/progrium/macdriver/objc"
-)
-
-// An interface for responding to messages from JavaScript code running in a webpage. [Full Topic]
-//
-// [Full Topic]: https://developer.apple.com/documentation/webkit/wkscriptmessagehandlerwithreply?language=objc
-type PScriptMessageHandlerWithReply interface {
-	// optional
-	UserContentControllerDidReceiveScriptMessageReplyHandler(userContentController UserContentController, message ScriptMessage, replyHandler func(reply objc.Object, errorMessage string))
-	HasUserContentControllerDidReceiveScriptMessageReplyHandler() bool
-}
-
-// A concrete type wrapper for the [PScriptMessageHandlerWithReply] protocol.
-type ScriptMessageHandlerWithReplyWrapper struct {
-	objc.Object
-}
-
-func (s_ ScriptMessageHandlerWithReplyWrapper) HasUserContentControllerDidReceiveScriptMessageReplyHandler() bool {
-	return s_.RespondsToSelector(objc.Sel("userContentController:didReceiveScriptMessage:replyHandler:"))
-}
-
-// Tells the handler that a webpage sent a script message that included a reply. [Full Topic]
-//
-// [Full Topic]: https://developer.apple.com/documentation/webkit/wkscriptmessagehandlerwithreply/3585111-usercontentcontroller?language=objc
-func (s_ ScriptMessageHandlerWithReplyWrapper) UserContentControllerDidReceiveScriptMessageReplyHandler(userContentController IUserContentController, message IScriptMessage, replyHandler func(reply objc.Object, errorMessage string)) {
-	objc.Call[objc.Void](s_, objc.Sel("userContentController:didReceiveScriptMessage:replyHandler:"), objc.Ptr(userContentController), objc.Ptr(message), replyHandler)
-}


### PR DESCRIPTION
As discussed, added type conversion support for *string values, then added code to skip generation for types defined in the custom source file (#185), and added a modified version of the protocol with the callback to use *string instead of string. updated related helper/custom code and the examples impacted by this.