### PR TITLE
Higher level subclassing API

### DIFF
--- a/objc/call.go
+++ b/objc/call.go
@@ -79,7 +79,7 @@ func directPointer(t reflect.Type) bool {
 // AddMethod adds an instance method using a Go function.
 // The first argument of the Go function should be the object instance,
 // the second argument should be the method selector.
-func AddMethod(class Class, sel Selector, f any) bool {
+func AddMethod(class IClass, sel Selector, f any) bool {
 	rf := reflect.ValueOf(f)
 
 	typeEncoding := _getMethodTypeEncoding(rf.Type(), false)
@@ -95,7 +95,7 @@ func AddMethod(class Class, sel Selector, f any) bool {
 // ReplaceMethod replaces an instance method using a Go function.
 // The first argument of the Go function should be the object instance,
 // the second argument should be the method selector.
-func ReplaceMethod(class Class, sel Selector, f any) {
+func ReplaceMethod(class IClass, sel Selector, f any) {
 	rf := reflect.ValueOf(f)
 	typeEncoding := _getMethodTypeEncoding(rf.Type(), false)
 
@@ -110,12 +110,12 @@ func ReplaceMethod(class Class, sel Selector, f any) {
 // AddClassMethod adds a class method using a Go function.
 // The first argument of the Go function should be the class,
 // the second argument should be the method selector.
-func AddClassMethod(class Class, sel Selector, f any) bool {
+func AddClassMethod(class IClass, sel Selector, f any) bool {
 	rf := reflect.ValueOf(f)
 	typeEncoding := _getMethodTypeEncoding(rf.Type(), true)
 
 	imp, handle := wrapGoFuncAsMethodIMP(rf)
-	metaClass := class.Class()
+	metaClass := class.MetaClass()
 	if metaClass.Ptr() == nil {
 		panic("no meta class")
 	}
@@ -129,7 +129,7 @@ func AddClassMethod(class Class, sel Selector, f any) bool {
 // ReplaceClassMethod replaces a class method using a Go function.
 // The first argument of the Go function should be the class,
 // the second argument should be the method selector.
-func ReplaceClassMethod(class Class, sel Selector, f any) {
+func ReplaceClassMethod(class IClass, sel Selector, f any) {
 	rf := reflect.ValueOf(f)
 	typeEncoding := _getMethodTypeEncoding(rf.Type(), true)
 

--- a/objc/class.go
+++ b/objc/class.go
@@ -42,7 +42,7 @@ type IClass interface {
 	Name() string
 	SetVersion(version int)
 	Version() int
-	Class() Class
+	MetaClass() Class
 	SuperClass() Class
 	RespondsToSelector(sel Selector) bool
 	AddMethod(sel Selector, imp IMP, types string) bool
@@ -90,14 +90,14 @@ func AllocateClass(superClass Class, name string, extraBytes uint) Class {
 // Registers a class that was allocated using [AllocateClass] [Full Topic]
 //
 // [Full Topic]: https://developer.apple.com/documentation/objectivec/1418603-objc_registerclasspair?language=objc
-func RegisterClass(class Class) {
+func RegisterClass(class IClass) {
 	C.Objc_RegisterClassPair(class.Ptr())
 }
 
 // Destroys a class and its associated metaclass. [Full Topic]
 //
 // [Full Topic]: https://developer.apple.com/documentation/objectivec/1418912-objc_disposeclasspair?language=objc
-func DisposeClass(class Class) {
+func DisposeClass(class IClass) {
 	C.Objc_DisposeClassPair(class.Ptr())
 }
 
@@ -112,7 +112,7 @@ func (c Class) Name() string {
 	return name
 }
 
-func (c Class) Class() Class {
+func (c Class) MetaClass() Class {
 	return ObjectFrom(c.ptr).Class()
 }
 

--- a/objc/userclass.go
+++ b/objc/userclass.go
@@ -1,0 +1,51 @@
+package objc
+
+import "reflect"
+
+// TODO:
+// - tests
+// - builtin method adding
+
+// UserClass is a generic wrapper around Class returned by NewClass.
+type UserClass[T IObject] struct {
+	Class
+}
+
+// New creates an instance of the class then calls init and autorelease before returning.
+func (c UserClass[T]) New() T {
+	var o T
+	oo := c.CreateInstance(0).PerformSelector(Sel("init"))
+	setPtr(&o, oo.Ptr())
+	o.Autorelease()
+	return o
+}
+
+// NewClass will allocate a new class using the name of the type passed
+// and NSObject as the superclass unless the passed type has a struct tag
+// with the key "objc" specifying the name of the superclass to use.
+// The returned class will still need to be registered.
+func NewClass[T IObject](selectors ...Selector) UserClass[T] {
+	var o T
+	typ := reflect.TypeOf(o)
+	var super string
+	for i := 0; i < typ.NumField(); i++ {
+		super = typ.Field(i).Tag.Get("objc")
+		if super != "" {
+			break
+		}
+	}
+	if super == "" {
+		super = "NSObject"
+	}
+	cls := AllocateClass(GetClass(super), typ.Name(), 0)
+	for _, sel := range selectors {
+		m, ok := typ.MethodByName(selectorToGoName(sel.Name()))
+		if !ok {
+			panic("allocating class from struct without method for selector: " + sel.Name())
+		}
+		AddMethod(cls, sel, m.Func.Interface())
+	}
+	return UserClass[T]{
+		Class: cls,
+	}
+}

--- a/objc/userclass.go
+++ b/objc/userclass.go
@@ -2,10 +2,6 @@ package objc
 
 import "reflect"
 
-// TODO:
-// - tests
-// - builtin method adding
-
 // UserClass is a generic wrapper around Class returned by NewClass.
 type UserClass[T IObject] struct {
 	Class

--- a/objc/userclass_test.go
+++ b/objc/userclass_test.go
@@ -1,0 +1,80 @@
+package objc
+
+import (
+	"testing"
+
+	"github.com/progrium/macdriver/internal/assert"
+)
+
+// uses NSObject as super without struct tag, regardless of embedded type.
+type FooObject struct {
+	Object
+}
+
+func (f FooObject) MethodForFoo() string {
+	return "foo"
+}
+
+// uses FooObject from struct tag as super, which should be registered first.
+type BarObject struct {
+	FooObject `objc:"FooObject"`
+}
+
+func (b BarObject) MethodForBar() string {
+	return "bar"
+}
+
+func TestNewClass(t *testing.T) {
+	FooObjectClass := NewClass[FooObject](
+		Sel("methodForFoo"),
+	)
+	RegisterClass(FooObjectClass)
+
+	BarObjectClass := NewClass[BarObject](
+		Sel("methodForBar"),
+	)
+	RegisterClass(BarObjectClass)
+
+	// as per our rules, New returned objects are autoreleased
+	WithAutoreleasePool(func() {
+		foo := FooObjectClass.New()
+		// foo go method
+		if foo.MethodForFoo() != "foo" {
+			t.Fatal("unexpected return")
+		}
+		// foo objc method
+		fooRet := foo.PerformSelector(Sel("methodForFoo"))
+		if ToGoString(fooRet.Ptr()) != "foo" {
+			t.Fatal("unexpected return")
+		}
+
+		bar := BarObjectClass.New()
+		// bar go method
+		if bar.MethodForBar() != "bar" {
+			t.Fatal("unexpected return")
+		}
+		// bar objc method
+		barRet := bar.PerformSelector(Sel("methodForBar"))
+		if ToGoString(barRet.Ptr()) != "bar" {
+			t.Fatal("unexpected return")
+		}
+		// as well as foo go method
+		if bar.MethodForFoo() != "foo" {
+			t.Fatal("unexpected return")
+		}
+		// and foo objc method
+		barRet = bar.PerformSelector(Sel("methodForFoo"))
+		if ToGoString(barRet.Ptr()) != "foo" {
+			t.Fatal("unexpected return")
+		}
+	})
+
+}
+
+func TestNewClassNoMethod(t *testing.T) {
+	assert.Panics(t, func() {
+		NewClass[FooObject](
+			Sel("noMethodLikeThisOnFooObject"),
+		)
+	})
+}


### PR DESCRIPTION
This PR introduces `objc.NewClass[T]()`, which takes a struct type implementing IObject that it uses to allocate a class. It uses reflection to set the class name from the struct type name, and uses NSObject as the super unless specified by a struct tag. It optionally takes selectors that will be added as methods using the struct methods with Go equivalent name. The resulting class can be registered and has a type specific New() that initializes and autoreleases. 

## Example 

```go
type CustomView struct {
	appkit.View `objc:"NSView"`
}

func (v CustomView) AcceptsFirstResponder() bool {
	return true
}

func (v CustomView) KeyDown(event appkit.Event) {
	log.Println("Keydown:", v.Class().Name(), event.Class().Name())
}

func main() {
	// passing a selector that doesn't have a matching Go method will panic
	CustomViewClass := objc.NewClass[CustomView](
		objc.Sel("acceptsFirstResponder"),
		objc.Sel("keyDown:"),
	)
	objc.RegisterClass(CustomViewClass)

	// New() returns a CustomView, but InitWithFrame() will return a View.
	// If you need CustomView, you can assign it before the View init method.
	view := CustomViewClass.New().InitWithFrame(rectOf(0, 0, 150, 99))

	...
}
```

More examples can be found in the tests or the updated subclass example.

## Breaking Changes

Changes the `Class()` method on `objc.Class` and `objc.IClass` to `MetaClass()`. 