### PR TITLE
Adding lat long fields to corelocation.LocationCoordinate2D

### DIFF
--- a/macos/corelocation/corelocation_structs.go
+++ b/macos/corelocation/corelocation_structs.go
@@ -1,3 +1,6 @@
 package corelocation
 
-type LocationCoordinate2D struct{}
+type LocationCoordinate2D struct {
+	latitude  LocationDegrees
+	longitude LocationDegrees
+}

--- a/macos/corelocation/corelocation_structs.go
+++ b/macos/corelocation/corelocation_structs.go
@@ -1,6 +1,6 @@
 package corelocation
 
 type LocationCoordinate2D struct {
-	latitude  LocationDegrees
-	longitude LocationDegrees
+	Latitude  LocationDegrees
+	Longitude LocationDegrees
 }


### PR DESCRIPTION
After getting location data from corelocation, the Coordinate returned is an empty struct. This should solve that problem.