### PR TITLE
Fix: FormView setting row spacing infinite loop & layout pin anchor remove cast appkit.LayoutAnchor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,3 @@ module github.com/progrium/macdriver
 go 1.18
 
 require github.com/go-test/deep v1.1.0
-
-require (
-	github.com/yuin/goldmark v1.5.5 // indirect
-	golang.org/x/mod v0.12.0 // indirect
-	golang.org/x/sys v0.11.0 // indirect
-	golang.org/x/tools v0.12.0 // indirect
-)

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,2 @@
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
-github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuin/goldmark v1.5.5 h1:IJznPe8wOzfIKETmMkd06F8nXkmlhaHqFRM9l1hAGsU=
-github.com/yuin/goldmark v1.5.5/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
-golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
-golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.12.0 h1:YW6HUoUmYBpwSgyaGaZq1fHjrBjX1rlpZ54T6mu2kss=
-golang.org/x/tools v0.12.0/go.mod h1:Sc0INKfu04TlqNoRA1hgpFZbhYXHPr4V5DzpSBTPqQM=

--- a/helper/layout/layout.go
+++ b/helper/layout/layout.go
@@ -50,9 +50,7 @@ func AliginCenterY(view appkit.IView, targetView appkit.IView) {
 }
 
 func PinAnchorTo(anchor appkit.ILayoutAnchor, targetAncor appkit.ILayoutAnchor, offset float64) {
-	// we do this because this method was not added to ILayoutAnchor, but we
-	// added it to LayoutAnchor manually
-	anchor.(appkit.LayoutAnchor).ConstraintEqualToAnchorConstant(targetAncor, offset).SetActive(true)
+	anchor.ConstraintEqualToAnchorConstant(targetAncor, offset).SetActive(true)
 }
 
 // PinEdgesToSuperView set view's insets to it's super view.

--- a/helper/widgets/form_view.go
+++ b/helper/widgets/form_view.go
@@ -56,7 +56,7 @@ func (f *FormView) InsertRow(index int, name string, control appkit.IControl) {
 
 // SetRowSpacing set spacing between rows.
 func (f *FormView) SetRowSpacing(spacing float64) {
-	f.SetRowSpacing(spacing)
+	f.GridView.SetRowSpacing(spacing)
 }
 
 // SetLabelWidth set width for labels


### PR DESCRIPTION
1. `FormView` embedding `appkit.GridView`, But `GridView` itself has a `SetRowSpacing` method, so the `SetRowSpacing` method of `GridView` should be called in `FormView`, Otherwise it will lead to an infinite loop. effect: `f.GridView.SetRowSpacing(spacing)`
2. `appkit.ILayoutAnchor` now has the `ConstraintEqualToAnchorConstant` method. There is no need to cast it to `appkit.LayoutAnchor`, otherwise it will cause panic, because for example, the return value of `view.TopAnchor()` is `appkit.LayoutYAxisAnchor` instead of `appkit.LayoutAnchor`. If forced conversion is performed, will cause panic