### PR TITLE
Fix bug with size variable's value not being set when map is empty

### DIFF
--- a/objc/type_convertion.m
+++ b/objc/type_convertion.m
@@ -65,6 +65,7 @@ dict to_c_items(void* ptr) {
     dict c_dict;
     NSArray * keys = [result_ allKeys];
     int size = [keys count];
+    c_dict.len = size;
     if (size > 0) {
         void** key_data = malloc(size * sizeof(void*));
         void** value_data = malloc(size * sizeof(void*));
@@ -76,7 +77,6 @@ dict to_c_items(void* ptr) {
         }
         c_dict.key_data = key_data;
         c_dict.value_data = value_data;
-        c_dict.len = size;
     }
     return c_dict;
 }


### PR DESCRIPTION
In the type_convertion.m file the method to_c_items() does not set the c_dict.len variable if the size is equal to zero. This pull request changes things so that the variable is set earlier in the method so the size of the array does not stop the c_dict.len variable from being set.