### PR TITLE
Fix issues with map type

### DIFF
--- a/macos/foundation/foundation_test.go
+++ b/macos/foundation/foundation_test.go
@@ -1,8 +1,12 @@
 package foundation
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/progrium/macdriver/objc"
 )
 
 func TestFoundationValid(t *testing.T) {}
@@ -34,4 +38,80 @@ func TestFoundationArray(t *testing.T) {
 	}) {
 		t.Fatal("unexpected final slice from array")
 	}
+}
+
+
+// Test the (NS)Error type
+func TestFoundationError(t *testing.T) {
+	t.Run("Empty Map", func(t *testing.T) {
+
+		// declare the variables
+		var domain ErrorDomain = "My Domain"
+		code := -99
+		userInfo := make(map[ErrorUserInfoKey]objc.IObject)
+
+		// create the (NS)Error object
+		myError := Error_ErrorWithDomainCodeUserInfo(domain, code, userInfo)
+
+		// check that length of map is zero
+		length := len(myError.UserInfo())
+		if length != 0 {
+			t.Log("Error: Empty map length is not zero")
+			t.Fail()
+		}
+	})
+
+	t.Run("Map with items in it", func(t *testing.T) {
+
+		// declare the variables
+		var domain ErrorDomain = "My Domain"
+		code := -99
+		userInfo := make(map[ErrorUserInfoKey]objc.IObject)
+		userInfo["one"] = String_StringWithString("ONE")
+		userInfo["two"] = String_StringWithString("TWO")
+		userInfo["three"] = String_StringWithString("THREE")
+		userInfo["four"] = String_StringWithString("FOUR")
+		userInfo["five"] = String_StringWithString("FIVE")
+
+		// create the (NS)Error object
+		myError := Error_ErrorWithDomainCodeUserInfo(domain, code, userInfo)
+
+		// check each key with its value to see if they go together
+		for key, value := range myError.UserInfo() {
+			goKey := fmt.Sprintf("%s", reflect.ValueOf(key))
+			goValue := string(value.Description())
+			if strings.ToUpper(goKey) != goValue {
+				message := fmt.Sprintf("Failure detected: %s != %s", strings.ToUpper(goKey), goValue)
+				t.Log(message)
+				t.Fail()
+			}
+		}
+	})
+
+	t.Run("Check domain and code parameters", func(t *testing.T) {
+
+		// declare the variables
+		var domain ErrorDomain = "My Domain"
+		code := -99
+		userInfo := make(map[ErrorUserInfoKey]objc.IObject)
+
+		// create the (NS)Error object
+		myError := Error_ErrorWithDomainCodeUserInfo(domain, code, userInfo)
+
+		// check domain
+		checkDomain := myError.Domain()
+		if domain != checkDomain {
+			message := fmt.Sprintf("Expected domain value %s - actual %s", domain, checkDomain)
+			t.Log(message)
+			t.Fail()
+		}
+
+		// check code
+		checkCode := myError.Code()
+		if code != checkCode {
+			message := fmt.Sprintf("Expected code value %d - actual %d", code, checkCode)
+			t.Log(message)
+			t.Fail()
+		}
+	})
 }

--- a/objc/type_convertion.go
+++ b/objc/type_convertion.go
@@ -254,7 +254,7 @@ func convertToGoValue(p unsafe.Pointer, t reflect.Type) reflect.Value {
 			return reflect.ValueOf(ToGoSlice(*(*unsafe.Pointer)(p), t).Interface())
 		}
 	case reflect.Map:
-		return reflect.ValueOf(ToGoMap(*(*unsafe.Pointer)(p), t))
+		return ToGoMap(*(*unsafe.Pointer)(p), t)
 	case reflect.Struct:
 		return reflect.NewAt(t, p).Elem()
 	case reflect.Func:

--- a/objc/type_convertion.m
+++ b/objc/type_convertion.m
@@ -65,6 +65,7 @@ dict to_c_items(void* ptr) {
     dict c_dict;
     NSArray * keys = [result_ allKeys];
     int size = [keys count];
+    c_dict.len = size;
     if (size > 0) {
         void** key_data = malloc(size * sizeof(void*));
         void** value_data = malloc(size * sizeof(void*));
@@ -76,7 +77,6 @@ dict to_c_items(void* ptr) {
         }
         c_dict.key_data = key_data;
         c_dict.value_data = value_data;
-        c_dict.len = size;
     }
     return c_dict;
 }


### PR DESCRIPTION
In the function type_convertion.go:convertToGoValue() it makes a call to reflect.ValueOf() for the reflect.Map case. This should not be done because the value that ToGoMap() returns is already of type reflect.Value. Also it makes type assertions fail for map types.

This program was used to test these two patches:

```
// Description: Test the (NS)Error class

package main

import f "github.com/progrium/macdriver/macos/foundation"
import "fmt"
import "github.com/progrium/macdriver/objc"
import "reflect"
import "github.com/progrium/macdriver/macos/appkit"

func main() {
	
	// declare the variables
	var domain f.ErrorDomain = "My Domain"
	code := -99
	var userInfo map[f.ErrorUserInfoKey]objc.IObject
	userInfo = make(map[f.ErrorUserInfoKey]objc.IObject)
	userInfo["one"] = f.String_StringWithString("ONE")
	userInfo["two"] = f.String_StringWithString("TWO")
	userInfo["three"] = f.String_StringWithString("THREE")
	userInfo["window"] = appkit.NewWindowWithSize(640, 480)

	// create the (NS)Error object
	myError := f.Error_ErrorWithDomainCodeUserInfo(domain, code, userInfo)
	
	// print out error and check field values
	fmt.Println("Testing Error class\n")
	fmt.Println("error.LocalizedDescription():", myError.LocalizedDescription())
	fmt.Print("error.Code(): ", myError.Code())
	if myError.Code() == code {
		fmt.Println("...correct")
	} else {
		fmt.Println("...wrong")
	}
	
	fmt.Print("error.Domain(): ", myError.Domain())
	if myError.Domain() == domain {
		fmt.Println("...correct")
	} else {
		fmt.Println("...wrong")
	}
	
	fmt.Println("error.UserInfo() value:", myError.UserInfo())
	fmt.Println("error.UserInfo() type:", reflect.TypeOf(myError.UserInfo()))
	fmt.Println("\texpected type: map[foundation.ErrorUserInfoKey]objc.IObject)")

	fmt.Println("\nReturned userinfo values:")
	for k,v := range myError.UserInfo() {
		fmt.Printf("key: %s\tvalue: %s\n", k, v.Description())
	}
	
	fmt.Println("\nExpected userinfo values:")
	for k,v := range myError.UserInfo() {
		fmt.Printf("key: %s\tvalue: %s\n", k, v.Description())
	}
}
```

Before these patches this program would panic at the call to myError.UserInfo(). With the patches applied this program works correctly.