### PR TITLE
Add pointer to pointer support

### DIFF
--- a/generate/codegen/gen_method.go
+++ b/generate/codegen/gen_method.go
@@ -116,7 +116,7 @@ func (m *Method) WriteGoCallCode(currentModule *modules.Module, typeName string,
 	for idx, p := range m.Params {
 		switch tt := p.Type.(type) {
 		case *typing.ClassType:
-			args = append(args, "objc.Ptr("+p.GoName()+")")
+			args = append(args, p.GoName())
 		case *typing.ProtocolType:
 			pvar := fmt.Sprintf("po%d", idx)
 			cw.WriteLineF("%s := objc.WrapAsProtocol(\"%s\", %s)", pvar, tt.Name, p.GoName())

--- a/generate/codegen/gen_param.go
+++ b/generate/codegen/gen_param.go
@@ -11,15 +11,22 @@ type Param struct {
 	Type      typing.Type
 	FieldName string // objc param field name(part of function name)
 	Object    bool   // version of param generalized to IObject for protocols
+	IsPtrPtr  bool
 }
 
 func (p *Param) String() string {
 	return p.FieldName + ":" + p.Name
 }
 
-// GoDeclare return go param declare code
+// Return Go parameter code
 func (p *Param) GoDeclare(currentModule *modules.Module, receiveFromObjc bool) string {
-	return p.GoName() + " " + p.Type.GoName(currentModule, receiveFromObjc)
+	returnValue := p.GoName() + " "
+	if p.IsPtrPtr == true { // Example: NSError **error
+		returnValue = returnValue + "unsafe.Pointer"
+	} else {
+		returnValue = returnValue + p.Type.GoName(currentModule, receiveFromObjc)
+	}
+	return returnValue
 }
 
 func (p *Param) ObjcDeclare() string {

--- a/generate/members.go
+++ b/generate/members.go
@@ -193,6 +193,7 @@ func (db *Generator) Members(fw string, sym Symbol, covariantTypes []string) (pr
 						Name:      arg.Name,
 						Type:      ptyp,
 						FieldName: st.Method.NameParts[idx],
+						IsPtrPtr:  arg.Type.IsPtrPtr,
 					}
 					params = append(params, param)
 				}


### PR DESCRIPTION
Pointer to pointer types are commonly used to provide a method a way to communicate information to calling methods. A popular example of this is to use NSError to communicate any error information. This pull request adds the ability for DarwinKit to correctly use pointer to pointer types so they can work.

This change uses a new rule where if a parameter is a pointer to a pointer type (e.g. NSError **error), the user is to use the Go wrapper for that type and wrap the variable with unsafe.Pointer(&theVariable). 

So for a parameter like NSError **err, the Go code would declare an Error instance and then use that instance in the method like this: unsafe.Pointer(&err)