### PR TITLE
Fix nil issue with several Array and Dictionary methods

### DIFF
--- a/generate/special/macos/foundation/special.go
+++ b/generate/special/macos/foundation/special.go
@@ -1,0 +1,178 @@
+// Description: where methods that can't work when generated are manually implemented.
+
+package foundation
+
+import (
+	"reflect"
+	"unsafe"
+
+	"github.com/progrium/macdriver/objc"
+)
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation
+#import <Foundation/Foundation.h>
+
+// makes a NSMutableDictionary from two NSArrays
+ void *MakeMutableDictionaryInternal(void *valuesPtr, void *keysPtr) {
+	 NSArray *keysArray = (NSArray *)keysPtr;
+	 NSArray *valuesArray = (NSArray *)valuesPtr;
+	 NSMutableDictionary *mdict = [[NSMutableDictionary alloc] init];
+	 for(int i = 0; i < [keysArray count]; i++) {
+		  [mdict setObject:[valuesArray objectAtIndex: i] forKey:[keysArray objectAtIndex: i]];
+	 }
+	 return mdict;
+ }
+
+// makes a NSMutableDictionary from two NSArrays
+void *MakeDictionaryInternal(void *valuesPtr, void *keysPtr) {
+	void *mdict = MakeMutableDictionaryInternal(valuesPtr, keysPtr);
+	return [NSDictionary dictionaryWithDictionary: mdict];
+}
+*/
+import "C"
+
+// tell the generation system not to generate these methods
+/*
+Note: fields: class selector note
+begin-skip
+"NSDictionary", "initWithObjectsAndKeys:", "using custom implementation"
+"NSDictionary", "dictionaryWithObjectsAndKeys:", "using custom implementation"
+"NSMutableDictionary", "initWithObjectsAndKeys:", "using custom implementation"
+"NSMutableDictionary", "dictionaryWithObjectsAndKeys:", "using custom implementation"
+"NSArray", "arrayWithObjects:", "using custom implementation"
+"NSArray", "initWithObjects:", "using custom implementation"
+"NSMutableArray", "arrayWithObjects:", "using custom implementation"
+"NSMutableArray", "initWithObjects:", "using custom implementation"
+end-skip
+*/
+
+// create an array for values and a array for keys using one array
+func createKeyValueArrays(args []objc.IObject) (unsafe.Pointer, unsafe.Pointer) {
+	keys := make([]objc.IObject, 0)
+	values := make([]objc.IObject, 0)
+	for i := 0; i < len(args); i++ {
+		if i%2 == 0 {
+			// if last item is nil
+			if i == len(args)-1 && args[i] == nil {
+				continue // remove terminating nil
+			}
+			values = append(values, args[i])
+		} else {
+			keys = append(keys, args[i])
+		}
+	}
+	valuesArray := objc.ToNSArray(reflect.ValueOf(values))
+	keysArray := objc.ToNSArray(reflect.ValueOf(keys))
+	return keysArray, valuesArray
+}
+
+// Uses key-value pairs to make a dictionary
+func makeDictionary(args []objc.IObject) Dictionary {
+	keysArray, valuesArray := createKeyValueArrays(args)
+	pointer := C.MakeDictionaryInternal(valuesArray, keysArray)
+	dict := DictionaryFrom(pointer)
+	return dict
+}
+
+// Uses key-value pairs to make a mutable dictionary
+func makeMutableDictionary(args []objc.IObject) MutableDictionary {
+	keysArray, valuesArray := createKeyValueArrays(args)
+	pointer := C.MakeMutableDictionaryInternal(valuesArray, keysArray)
+	mdict := MutableDictionaryFrom(pointer)
+	return mdict
+}
+
+/** Dictionary class methods **/
+
+// implemented here because Go's nil causes an exception to be thrown
+func (a_ Dictionary) InitWithObjectsAndKeys(firstObject objc.IObject, args ...objc.IObject) Dictionary {
+	args = append([]objc.IObject{firstObject}, args...)
+	dict := makeDictionary(args)
+	return dict
+}
+
+// implemented here because Go's nil causes an exception to be thrown
+func Dictionary_DictionaryWithObjectsAndKeys(firstObject objc.IObject, args ...objc.IObject) Dictionary {
+	args = append([]objc.IObject{firstObject}, args...)
+	dict := makeDictionary(args)
+	return dict
+}
+
+func NewDictionaryWithObjectsAndKeys(firstObject objc.IObject, args ...objc.IObject) Dictionary {
+	args = append([]objc.IObject{firstObject}, args...)
+	dict := makeDictionary(args)
+	return dict
+}
+
+/** MutableDictionary class methods **/
+
+// implemented here because Go's nil causes an exception to be thrown
+func (a_ MutableDictionary) InitWithObjectsAndKeys(firstObject objc.IObject, args ...objc.IObject) MutableDictionary {
+	args = append([]objc.IObject{firstObject}, args...)
+	mdict := makeMutableDictionary(args)
+	return mdict
+}
+
+// implemented here because Go's nil causes an exception to be thrown
+func MutableDictionary_DictionaryWithObjectsAndKeys(firstObject objc.IObject, args ...objc.IObject) MutableDictionary {
+	args = append([]objc.IObject{firstObject}, args...)
+	mdict := makeMutableDictionary(args)
+	return mdict
+}
+
+func NewMutableDictionaryWithObjectsAndKeys(firstObject objc.IObject, args ...objc.IObject) MutableDictionary {
+	args = append([]objc.IObject{firstObject}, args...)
+	mdict := makeMutableDictionary(args)
+	return mdict
+}
+
+/** Array class methods **/
+
+// implemented here because only one object appears in the array otherwise
+func Array_ArrayWithObjects(firstObject objc.IObject, args ...objc.IObject) Array {
+	args = append([]objc.IObject{firstObject}, args...)
+	arrayPtr := objc.ToNSArray(reflect.ValueOf(args))
+	newArray := ArrayFrom(arrayPtr)
+	return newArray
+}
+
+// implemented here because only one object appears in the array otherwise
+func (a_ Array) InitWithObjects(firstObj objc.IObject, args ...objc.IObject) Array {
+	args = append([]objc.IObject{firstObj}, args...)
+	arrayPtr := objc.ToNSArray(reflect.ValueOf(args))
+	newArray := ArrayFrom(arrayPtr)
+	return newArray
+}
+
+// implemented here because only one object appears in the array otherwise
+func NewArrayWithObjects(firstObj objc.IObject, args ...objc.IObject) Array {
+	args = append([]objc.IObject{firstObj}, args...)
+	arrayPtr := objc.ToNSArray(reflect.ValueOf(args))
+	newArray := ArrayFrom(arrayPtr)
+	return newArray
+}
+
+/** MutableArray class methods **/
+
+// implemented here because only one object appears in the array otherwise
+func MutableArray_ArrayWithObjects(firstObj objc.IObject, args ...objc.IObject) MutableArray {
+	args = append([]objc.IObject{firstObj}, args...)
+	mArray := MutableArray_ArrayWithArray(args)
+	return mArray
+}
+
+// implemented here because only one object appears in the array otherwise
+func (a_ MutableArray) InitWithObjects(firstObj objc.IObject, args ...objc.IObject) MutableArray {
+	args = append([]objc.IObject{firstObj}, args...)
+	mArray := MutableArray_ArrayWithArray(args)
+	return mArray
+}
+
+// implemented here because only one object appears in the array otherwise
+func NewMutableArrayWithObjects(firstObj objc.IObject, args ...objc.IObject) MutableArray {
+	args = append([]objc.IObject{firstObj}, args...)
+	mArray := MutableArray_ArrayWithArray(args)
+	return mArray
+}

--- a/macos/foundation/array.gen.go
+++ b/macos/foundation/array.gen.go
@@ -150,20 +150,6 @@ func Array_ArrayWithObject(anObject objc.IObject) Array {
 	return ArrayClass.ArrayWithObject(anObject)
 }
 
-func (a_ Array) InitWithObjects(firstObj objc.IObject, args ...any) Array {
-	rv := objc.Call[Array](a_, objc.Sel("initWithObjects:"), append([]any{objc.Ptr(firstObj)}, args...)...)
-	return rv
-}
-
-// Initializes a newly allocated array by placing in it the objects in the argument list. [Full Topic]
-//
-// [Full Topic]: https://developer.apple.com/documentation/foundation/nsarray/1460068-initwithobjects?language=objc
-func NewArrayWithObjects(firstObj objc.IObject, args ...any) Array {
-	instance := ArrayClass.Alloc().InitWithObjects(firstObj, args...)
-	instance.Autorelease()
-	return instance
-}
-
 func (ac _ArrayClass) Array() Array {
 	rv := objc.Call[Array](ac, objc.Sel("array"))
 	return rv
@@ -200,18 +186,6 @@ func (ac _ArrayClass) ArrayWithObjectsCount(objects objc.IObject, cnt uint) Arra
 // [Full Topic]: https://developer.apple.com/documentation/foundation/nsarray/1460096-arraywithobjects?language=objc
 func Array_ArrayWithObjectsCount(objects objc.IObject, cnt uint) Array {
 	return ArrayClass.ArrayWithObjectsCount(objects, cnt)
-}
-
-func (ac _ArrayClass) ArrayWithObjects(firstObj objc.IObject, args ...any) Array {
-	rv := objc.Call[Array](ac, objc.Sel("arrayWithObjects:"), append([]any{objc.Ptr(firstObj)}, args...)...)
-	return rv
-}
-
-// Creates and returns an array containing the objects in the argument list. [Full Topic]
-//
-// [Full Topic]: https://developer.apple.com/documentation/foundation/nsarray/1460145-arraywithobjects?language=objc
-func Array_ArrayWithObjects(firstObj objc.IObject, args ...any) Array {
-	return ArrayClass.ArrayWithObjects(firstObj, args...)
 }
 
 func (ac _ArrayClass) Alloc() Array {

--- a/macos/foundation/dictionary.gen.go
+++ b/macos/foundation/dictionary.gen.go
@@ -89,32 +89,6 @@ func NewDictionaryWithDictionary(otherDictionary Dictionary) Dictionary {
 	return instance
 }
 
-func (dc _DictionaryClass) DictionaryWithObjectsAndKeys(firstObject objc.IObject, args ...any) Dictionary {
-	rv := objc.Call[Dictionary](dc, objc.Sel("dictionaryWithObjectsAndKeys:"), append([]any{firstObject}, args...)...)
-	return rv
-}
-
-// Creates a dictionary containing entries constructed from the specified set of values and keys. [Full Topic]
-//
-// [Full Topic]: https://developer.apple.com/documentation/foundation/nsdictionary/1574181-dictionarywithobjectsandkeys?language=objc
-func Dictionary_DictionaryWithObjectsAndKeys(firstObject objc.IObject, args ...any) Dictionary {
-	return DictionaryClass.DictionaryWithObjectsAndKeys(firstObject, args...)
-}
-
-func (d_ Dictionary) InitWithObjectsAndKeys(firstObject objc.IObject, args ...any) Dictionary {
-	rv := objc.Call[Dictionary](d_, objc.Sel("initWithObjectsAndKeys:"), append([]any{firstObject}, args...)...)
-	return rv
-}
-
-// Initializes a newly allocated dictionary with entries constructed from the specified set of values and keys. [Full Topic]
-//
-// [Full Topic]: https://developer.apple.com/documentation/foundation/nsdictionary/1574190-initwithobjectsandkeys?language=objc
-func NewDictionaryWithObjectsAndKeys(firstObject objc.IObject, args ...any) Dictionary {
-	instance := DictionaryClass.Alloc().InitWithObjectsAndKeys(firstObject, args...)
-	instance.Autorelease()
-	return instance
-}
-
 func (d_ Dictionary) Init() Dictionary {
 	rv := objc.Call[Dictionary](d_, objc.Sel("init"))
 	return rv

--- a/macos/foundation/mutable_array.gen.go
+++ b/macos/foundation/mutable_array.gen.go
@@ -161,20 +161,6 @@ func MutableArray_ArrayWithObject(anObject objc.IObject) MutableArray {
 	return MutableArrayClass.ArrayWithObject(anObject)
 }
 
-func (m_ MutableArray) InitWithObjects(firstObj objc.IObject, args ...any) MutableArray {
-	rv := objc.Call[MutableArray](m_, objc.Sel("initWithObjects:"), append([]any{objc.Ptr(firstObj)}, args...)...)
-	return rv
-}
-
-// Initializes a newly allocated array by placing in it the objects in the argument list. [Full Topic]
-//
-// [Full Topic]: https://developer.apple.com/documentation/foundation/nsarray/1460068-initwithobjects?language=objc
-func NewMutableArrayWithObjects(firstObj objc.IObject, args ...any) MutableArray {
-	instance := MutableArrayClass.Alloc().InitWithObjects(firstObj, args...)
-	instance.Autorelease()
-	return instance
-}
-
 func (mc _MutableArrayClass) Array() MutableArray {
 	rv := objc.Call[MutableArray](mc, objc.Sel("array"))
 	return rv
@@ -211,18 +197,6 @@ func (mc _MutableArrayClass) ArrayWithObjectsCount(objects objc.IObject, cnt uin
 // [Full Topic]: https://developer.apple.com/documentation/foundation/nsarray/1460096-arraywithobjects?language=objc
 func MutableArray_ArrayWithObjectsCount(objects objc.IObject, cnt uint) MutableArray {
 	return MutableArrayClass.ArrayWithObjectsCount(objects, cnt)
-}
-
-func (mc _MutableArrayClass) ArrayWithObjects(firstObj objc.IObject, args ...any) MutableArray {
-	rv := objc.Call[MutableArray](mc, objc.Sel("arrayWithObjects:"), append([]any{objc.Ptr(firstObj)}, args...)...)
-	return rv
-}
-
-// Creates and returns an array containing the objects in the argument list. [Full Topic]
-//
-// [Full Topic]: https://developer.apple.com/documentation/foundation/nsarray/1460145-arraywithobjects?language=objc
-func MutableArray_ArrayWithObjects(firstObj objc.IObject, args ...any) MutableArray {
-	return MutableArrayClass.ArrayWithObjects(firstObj, args...)
 }
 
 // Removes from the receiving array the objects in another given array. [Full Topic]

--- a/macos/foundation/mutable_dictionary.gen.go
+++ b/macos/foundation/mutable_dictionary.gen.go
@@ -150,32 +150,6 @@ func NewMutableDictionaryWithDictionary(otherDictionary Dictionary) MutableDicti
 	return instance
 }
 
-func (mc _MutableDictionaryClass) DictionaryWithObjectsAndKeys(firstObject objc.IObject, args ...any) MutableDictionary {
-	rv := objc.Call[MutableDictionary](mc, objc.Sel("dictionaryWithObjectsAndKeys:"), append([]any{firstObject}, args...)...)
-	return rv
-}
-
-// Creates a dictionary containing entries constructed from the specified set of values and keys. [Full Topic]
-//
-// [Full Topic]: https://developer.apple.com/documentation/foundation/nsdictionary/1574181-dictionarywithobjectsandkeys?language=objc
-func MutableDictionary_DictionaryWithObjectsAndKeys(firstObject objc.IObject, args ...any) MutableDictionary {
-	return MutableDictionaryClass.DictionaryWithObjectsAndKeys(firstObject, args...)
-}
-
-func (m_ MutableDictionary) InitWithObjectsAndKeys(firstObject objc.IObject, args ...any) MutableDictionary {
-	rv := objc.Call[MutableDictionary](m_, objc.Sel("initWithObjectsAndKeys:"), append([]any{firstObject}, args...)...)
-	return rv
-}
-
-// Initializes a newly allocated dictionary with entries constructed from the specified set of values and keys. [Full Topic]
-//
-// [Full Topic]: https://developer.apple.com/documentation/foundation/nsdictionary/1574190-initwithobjectsandkeys?language=objc
-func NewMutableDictionaryWithObjectsAndKeys(firstObject objc.IObject, args ...any) MutableDictionary {
-	instance := MutableDictionaryClass.Alloc().InitWithObjectsAndKeys(firstObject, args...)
-	instance.Autorelease()
-	return instance
-}
-
 func (mc _MutableDictionaryClass) DictionaryWithObjectsForKeys(objects []objc.IObject, keys []PCopying) MutableDictionary {
 	rv := objc.Call[MutableDictionary](mc, objc.Sel("dictionaryWithObjects:forKeys:"), objects, keys)
 	return rv


### PR DESCRIPTION
Several foundation methods take a list of objects and expect a nil to be used to terminate the list. Problem is the nil these methods want is an Objective-c nil. Using Go's nil causes a crash to take place. 

This pull request fixes the issue with several nil terminated methods. The way I fixed the issue was by introducing a new system that uses a file called special.go to override and prevent the generation of specified methods.

A new folder called special will be in the "generated" folder of DarwinKit. In this folder will be a platform folder. Currently we have a macOS folder. Inside the platform folder is a framework folder. This currently has a foundation folder. Inside this folder is a file called special.go. This file will contain the definition for methods that we don't want the generation system to make. To tell the generation system not to try to generate any method, the special.go file will contain a table. This table has this format:

```
/*
begin-skip
"class", "selector:", "note"
end-skip
*/
```

It is all located inside a comment. It begins with the text "begin-skip" on its own line, and ends with the text "end-skip" on its own line. Between these lines will be three fields that are separated by commas and each is wrapped with double quotes.  The fields will be an objective-c class name, a selector, and a note. 
Example:  "NSMutableDictionary", "initWithObjectsAndKeys:", "using custom implementation"

With this pull request methods like MutableDictionary's InitWithObjectsAndKeys() will actually work. Go's nil can be used to terminate the list or it can be omitted. 