### PR TITLE
Fix enumexport and interface param name

### DIFF
--- a/generate/codegen/gen_param.go
+++ b/generate/codegen/gen_param.go
@@ -35,7 +35,7 @@ func (p *Param) ObjcDeclare() string {
 
 func (p *Param) GoName() (name string) {
 	switch p.Name {
-	case "type", "range", "map", "string", "select":
+	case "type", "range", "map", "string", "select", "interface":
 		name = p.Name + "_"
 	default:
 		name = p.Name

--- a/generate/tools/enumexport.go
+++ b/generate/tools/enumexport.go
@@ -155,7 +155,7 @@ func exportConstants(db *generate.SymbolCache, framework *modules.Module, platfo
 			continue
 		}
 		if s.Kind == "Constant" && s.Type == "Global Variable" {
-			stmt, err := s.Parse()
+			stmt, err := s.Parse(platform)
 			if err != nil {
 				log.Fatalf("%s: %s in '%s'", s.Name, err, s.Declaration)
 			}
@@ -177,7 +177,7 @@ func exportConstants(db *generate.SymbolCache, framework *modules.Module, platfo
 				if typ.Declaration == "" {
 					return nil, false
 				}
-				typdef, err := typ.Parse()
+				typdef, err := typ.Parse(platform)
 				if err != nil {
 					log.Fatalf("%s: %s in '%s'", typ.Name, err, typ.Declaration)
 				}


### PR DESCRIPTION
- Fixed a bug in `enumexport` code by passing `platform` to funtion.
- Added `_` suffix to parameters named `interface` to not break Go code.

Closes #236.